### PR TITLE
Add alerting for NeTEx filtering failures

### DIFF
--- a/terraform/env/kub-ent-dev.tfvars
+++ b/terraform/env/kub-ent-dev.tfvars
@@ -5,3 +5,4 @@ bucket_instance_suffix="dev"
 service_account = "serviceAccount:application@ent-ashur-dev.iam.gserviceaccount.com"
 marduk_service_account = "serviceAccount:application@ent-marduk-dev.iam.gserviceaccount.com"
 ashur_exchange_storage_bucket="ror-ashur-exchange-gcp-dev"
+enable_slack_notifications = true

--- a/terraform/env/kub-ent-prd.tfvars
+++ b/terraform/env/kub-ent-prd.tfvars
@@ -5,3 +5,4 @@ bucket_instance_suffix="prd"
 service_account = "serviceAccount:application@ent-ashur-prd.iam.gserviceaccount.com"
 marduk_service_account = "serviceAccount:application@ent-marduk-prd.iam.gserviceaccount.com"
 ashur_exchange_storage_bucket="ror-ashur-exchange-gcp-prd"
+enable_slack_notifications = true

--- a/terraform/env/kub-ent-tst.tfvars
+++ b/terraform/env/kub-ent-tst.tfvars
@@ -5,3 +5,4 @@ bucket_instance_suffix="tst"
 service_account = "serviceAccount:application@ent-ashur-tst.iam.gserviceaccount.com"
 marduk_service_account = "serviceAccount:application@ent-marduk-tst.iam.gserviceaccount.com"
 ashur_exchange_storage_bucket="ror-ashur-exchange-gcp-tst"
+enable_slack_notifications = true

--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -1,0 +1,57 @@
+resource "google_logging_metric" "filtering_failures" {
+  name    = "ashur/filtering_failures"
+  project = var.ashur_project
+
+  description = "Counts NeTEx filtering runs that ended with status FAILED in Ashur."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.namespace_name="ashur"
+    jsonPayload.message:"Publishing processing status FAILED"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Ashur filtering failures"
+  }
+}
+
+data "google_monitoring_notification_channel" "slack_alerts" {
+  count = var.enable_slack_notifications ? 1 : 0
+
+  project      = var.ashur_project
+  display_name = "Ashur Slack Alert"
+  type         = "slack"
+}
+
+resource "google_monitoring_alert_policy" "filtering_failures" {
+  project      = var.ashur_project
+  display_name = "Ashur filtering failures"
+  combiner     = "OR"
+  user_labels  = var.labels
+
+  conditions {
+    display_name = "Failed filtering runs in the last 10 minutes"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.filtering_failures.name}\" resource.type=\"k8s_container\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+      aggregations {
+        alignment_period   = "600s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = data.google_monitoring_notification_channel.slack_alerts[*].name
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -81,3 +81,9 @@ variable "bucket_retention_period" {
   description = "Retention period for GCS objects (both current and non-current versions), in days"
   default     = "90"
 }
+
+variable "enable_slack_notifications" {
+  description = "Whether to look up the Slack notification channel and route alerts to it. The channel must be created manually in the GCP console first."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds a log-based metric counting filtering runs that end with status FAILED, and an alert policy that fires when any such failure occurs within a 10-minute window. Alerts are delivered to Slack via a manually-created notification channel, gated per environment by the new enable_slack_notifications variable.