### PR TITLE
Adds Prometheus metrics for filtering

### DIFF
--- a/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
@@ -7,12 +7,15 @@ import org.entur.ror.ashur.Constants
 import org.entur.ror.ashur.addPubsubAttribute
 import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.exceptions.AshurException
+import org.entur.ror.ashur.metrics.FilterMetrics
+import org.entur.ror.ashur.metrics.RecordFilterRunProcessor
 import org.entur.ror.ashur.report.CreateFilteringReportProcessor
 
 open class BaseRouteBuilder(
     val appConfig: AppConfig,
     val netexFilterMessageProcessor: NetexFilterMessageProcessor,
     val createFilteringReportProcessor: CreateFilteringReportProcessor,
+    val filterMetrics: FilterMetrics,
 ): RouteBuilder() {
     val ashurProjectId = appConfig.gcp.ashurProjectId
     val mardukProjectId = appConfig.gcp.mardukProjectId
@@ -58,6 +61,7 @@ open class BaseRouteBuilder(
 
         from("direct:filterProcessingStatusFailed")
             .process(SetFilteringStatusProcessor(status = Constants.FILTER_NETEX_FILE_STATUS_FAILED))
+            .process(RecordFilterRunProcessor(filterMetrics, successful = false))
             .process(createFilteringReportProcessor)
             .log(LoggingLevel.INFO, "Publishing processing status FAILED for codespace: \${header.codespace}")
             .to("google-pubsub:$mardukProjectId:$statusTopic")

--- a/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
@@ -6,6 +6,8 @@ import org.entur.ror.ashur.addPubsubAttribute
 import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.getCodespace
 import org.entur.ror.ashur.getCorrelationId
+import org.entur.ror.ashur.metrics.FilterMetrics
+import org.entur.ror.ashur.metrics.RecordFilterRunProcessor
 import org.entur.ror.ashur.report.CreateFilteringReportProcessor
 import org.entur.ror.ashur.toPubsubMessage
 import org.springframework.stereotype.Component
@@ -20,7 +22,8 @@ class NetexFilterRouteBuilder(
     appConfig: AppConfig,
     netexFilterMessageProcessor: NetexFilterMessageProcessor,
     createFilteringReportProcessor: CreateFilteringReportProcessor,
-) : BaseRouteBuilder(appConfig, netexFilterMessageProcessor, createFilteringReportProcessor) {
+    filterMetrics: FilterMetrics,
+) : BaseRouteBuilder(appConfig, netexFilterMessageProcessor, createFilteringReportProcessor, filterMetrics) {
     override fun configure() {
         super.configure()
 
@@ -57,6 +60,7 @@ class NetexFilterRouteBuilder(
 
         from("direct:filterProcessingStatusSucceeded")
             .process(SetFilteringStatusProcessor(status = Constants.FILTER_NETEX_FILE_STATUS_SUCCEEDED))
+            .process(RecordFilterRunProcessor(filterMetrics, successful = true))
             .process(createFilteringReportProcessor)
             .process { exchange ->
                 exchange.addPubsubAttribute(

--- a/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
@@ -8,11 +8,13 @@ import org.entur.ror.ashur.exceptions.InvalidZipFileException
 import org.entur.ror.ashur.exceptions.NoJourneysInNetexFileException
 import org.entur.ror.ashur.file.AshurBucketService
 import org.entur.ror.ashur.file.MardukBucketService
+import org.entur.ror.ashur.metrics.FilterMetrics
 import org.entur.ror.ashur.utils.FileUtils
 import org.entur.ror.ashur.utils.ZipUtils
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.io.File
+import java.time.Duration
 
 data class FilterResult(
     val filteredZipFilePath: String,
@@ -27,6 +29,7 @@ class FilterService(
     private val ashurBucketService: AshurBucketService,
     private val mardukBucketService: MardukBucketService,
     private val appConfig: AppConfig,
+    private val filterMetrics: FilterMetrics,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -234,6 +237,7 @@ class FilterService(
         codespace: String,
         correlationId: String,
     ): FilterResult {
+        val runStartNanos = System.nanoTime()
         val netexInputFile = getZipFile(fileName)
         val localPathForInputFiles = getPathForNetexInputFiles(codespace, correlationId)
         val localPathForOutputFiles = getPathForNetexOutputFiles(codespace, correlationId)
@@ -276,6 +280,9 @@ class FilterService(
             )
             netexInputFile.delete()
         }
+
+        // Reached only when the run succeeded; failures throw before this point.
+        filterMetrics.recordSuccessfulRunDuration(codespace, Duration.ofNanos(System.nanoTime() - runStartNanos))
 
         return FilterResult(
             filteredZipFilePath = filteredZipFileName,

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
@@ -1,0 +1,52 @@
+package org.entur.ror.ashur.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+/**
+ * Emits application metrics for filtering runs.
+ *
+ * - [RUNS_METRIC_NAME] is a counter tagged with `status` (`success`/`failed`) and `codespace`.
+ *   In Prometheus this surfaces as `ashur_filter_runs_total`.
+ * - [DURATION_METRIC_NAME] is a timer tagged with `codespace`, recorded only for successful runs.
+ *   In Prometheus this surfaces as `ashur_filter_duration_seconds_count` / `_sum`, so the average
+ *   run time is `rate(..._sum[5m]) / rate(..._count[5m])`.
+ *
+ * Because `codespace` is a label, a Grafana dashboard can both group by codespace
+ * (`sum by (codespace) (...)`) and aggregate across codespaces (`sum without (codespace) (...)`).
+ */
+@Component
+class FilterMetrics(private val meterRegistry: MeterRegistry) {
+
+    fun incrementSuccessfulRun(codespace: String?) = increment(STATUS_SUCCESS, codespace)
+
+    fun incrementFailedRun(codespace: String?) = increment(STATUS_FAILED, codespace)
+
+    fun recordSuccessfulRunDuration(codespace: String?, duration: Duration) {
+        Timer.builder(DURATION_METRIC_NAME)
+            .tag("codespace", codespace.orUnknown())
+            .register(meterRegistry)
+            .record(duration)
+    }
+
+    private fun increment(status: String, codespace: String?) {
+        Counter.builder(RUNS_METRIC_NAME)
+            .tag("status", status)
+            .tag("codespace", codespace.orUnknown())
+            .register(meterRegistry)
+            .increment()
+    }
+
+    private fun String?.orUnknown(): String = this?.takeIf { it.isNotBlank() } ?: UNKNOWN_CODESPACE
+
+    companion object {
+        const val RUNS_METRIC_NAME = "ashur.filter.runs"
+        const val DURATION_METRIC_NAME = "ashur.filter.duration"
+        const val STATUS_SUCCESS = "success"
+        const val STATUS_FAILED = "failed"
+        const val UNKNOWN_CODESPACE = "unknown"
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/RecordFilterRunProcessor.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/RecordFilterRunProcessor.kt
@@ -1,0 +1,31 @@
+package org.entur.ror.ashur.metrics
+
+import org.apache.camel.Exchange
+import org.apache.camel.Processor
+
+/**
+ * Camel processor that records the outcome of a filtering run as a metric via [FilterMetrics].
+ *
+ * Reads the `codespace` routing header (set at route entry, and preserved on the exchange through
+ * both the success and the handled-exception paths) so the counter is tagged per codespace.
+ *
+ * @param filterMetrics the metrics component to record the run on.
+ * @param successful whether this processor sits on the success path (`true`) or the failure path (`false`).
+ */
+class RecordFilterRunProcessor(
+    private val filterMetrics: FilterMetrics,
+    private val successful: Boolean,
+) : Processor {
+    override fun process(exchange: Exchange) {
+        val codespace = exchange.getIn().getHeader(CODESPACE_HEADER, String::class.java)
+        if (successful) {
+            filterMetrics.incrementSuccessfulRun(codespace)
+        } else {
+            filterMetrics.incrementFailedRun(codespace)
+        }
+    }
+
+    companion object {
+        private const val CODESPACE_HEADER = "codespace"
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
@@ -1,5 +1,6 @@
 package org.entur.ror.ashur.camel
 
+import io.micrometer.core.instrument.MeterRegistry
 import org.apache.camel.CamelContext
 import org.apache.camel.ConsumerTemplate
 import org.apache.camel.ProducerTemplate
@@ -9,6 +10,7 @@ import org.entur.ror.ashur.AshurApplication
 import org.entur.ror.ashur.Constants
 import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.config.PubSubEmulatorTestBase
+import org.entur.ror.ashur.metrics.FilterMetrics
 import org.entur.ror.ashur.getCorrelationId
 import org.entur.ror.ashur.getFilterProfile
 import org.entur.ror.ashur.getPathOfFilteredFile
@@ -43,6 +45,9 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     @Autowired
     lateinit var context: CamelContext
 
+    @Autowired
+    lateinit var meterRegistry: MeterRegistry
+
     private val testCodespace = "test-codespace"
     private val testSource = "test-source"
     private val testFilteringProfile = "AsIsImportFilter"
@@ -67,6 +72,18 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     }
 
     private val mapper = jacksonObjectMapper()
+
+    fun runCount(status: String): Double =
+        meterRegistry.find(FilterMetrics.RUNS_METRIC_NAME)
+            .tags("status", status, "codespace", testCodespace)
+            .counter()
+            ?.count() ?: 0.0
+
+    fun durationRunCount(): Long =
+        meterRegistry.find(FilterMetrics.DURATION_METRIC_NAME)
+            .tags("codespace", testCodespace)
+            .timer()
+            ?.count() ?: 0L
 
     fun pathOfFilteredFile(fileName: String, correlationId: String) = "${testCodespace}/${correlationId}/filtered_${fileName}"
     fun pathOfFilteringReport(correlationId: String) = "reports/${testCodespace}/filtering-report-${correlationId}.json"
@@ -105,6 +122,8 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
         copyTestZipFileToMardukTestBucket()
         val mardukProjectId = appConfig.gcp.mardukProjectId
         val correlationId = "success-correlation-id"
+        val successRunsBefore = runCount(FilterMetrics.STATUS_SUCCESS)
+        val durationRunsBefore = durationRunCount()
 
         sendFilterMessageToPubsub(
             netexFilePath = "testfile.zip",
@@ -143,6 +162,9 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
         val expectedFilteringReportPath = pathOfFilteringReport(correlationId)
         assertTrue(fileExistsInAshurInternalBucket(expectedFilteringReportPath))
 
+        assertEquals(successRunsBefore + 1.0, runCount(FilterMetrics.STATUS_SUCCESS))
+        assertEquals(durationRunsBefore + 1, durationRunCount())
+
         cleanupTestZipFiles()
     }
 
@@ -150,6 +172,8 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     fun `test filter route processes message but fails because file does not exist`() {
         val mardukProjectId = appConfig.gcp.mardukProjectId
         val failingCorrelationId = "failing-correlation-id"
+        val failedRunsBefore = runCount(FilterMetrics.STATUS_FAILED)
+        val durationRunsBefore = durationRunCount()
 
         sendFilterMessageToPubsub(netexFilePath = "unknown-file.zip", correlationId = failingCorrelationId)
 
@@ -181,6 +205,9 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
         assertEquals(testCodespace, failedReport.codespace)
         assertEquals(testFilteringProfile, failedReport.filterProfile)
         assertEquals(Constants.FILTER_NETEX_FILE_STATUS_FAILED, failedReport.status)
+
+        assertEquals(failedRunsBefore + 1.0, runCount(FilterMetrics.STATUS_FAILED))
+        assertEquals(durationRunsBefore, durationRunCount())
 
         cleanupTestZipFiles()
     }

--- a/src/test/kotlin/org/entur/ror/ashur/filter/FilterServiceTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/filter/FilterServiceTest.kt
@@ -5,6 +5,7 @@ import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.config.PubSubEmulatorTestBase
 import org.entur.ror.ashur.file.AshurBucketService
 import org.entur.ror.ashur.file.MardukBucketService
+import org.entur.ror.ashur.metrics.FilterMetrics
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,9 +25,12 @@ class FilterServiceTest(@Autowired var filterService: FilterService) : PubSubEmu
     @Autowired
     lateinit var appConfig: AppConfig
 
+    @Autowired
+    lateinit var filterMetrics: FilterMetrics
+
     @BeforeEach
     fun setUp() {
-        filterService = FilterService(ashurBucketService, mardukBucketService, appConfig)
+        filterService = FilterService(ashurBucketService, mardukBucketService, appConfig, filterMetrics)
     }
 
     @Test

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
@@ -1,0 +1,114 @@
+package org.entur.ror.ashur.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FilterMetricsTest {
+    private fun counterFor(
+        registry: SimpleMeterRegistry,
+        status: String,
+        codespace: String,
+    ): Double =
+        registry.find(FilterMetrics.RUNS_METRIC_NAME)
+            .tags("status", status, "codespace", codespace)
+            .counter()
+            ?.count() ?: 0.0
+
+    private fun durationCount(registry: SimpleMeterRegistry, codespace: String): Long =
+        registry.find(FilterMetrics.DURATION_METRIC_NAME)
+            .tags("codespace", codespace)
+            .timer()
+            ?.count() ?: 0L
+
+    private fun durationTotalMillis(registry: SimpleMeterRegistry, codespace: String): Double =
+        registry.find(FilterMetrics.DURATION_METRIC_NAME)
+            .tags("codespace", codespace)
+            .timer()
+            ?.totalTime(TimeUnit.MILLISECONDS) ?: 0.0
+
+    @Test
+    fun `incrementSuccessfulRun records one run tagged status=success and codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.incrementSuccessfulRun("RUT")
+
+        assertEquals(1.0, counterFor(registry, "success", "RUT"))
+        assertEquals(0.0, counterFor(registry, "failed", "RUT"))
+    }
+
+    @Test
+    fun `incrementFailedRun records one run tagged status=failed and codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.incrementFailedRun("RUT")
+
+        assertEquals(1.0, counterFor(registry, "failed", "RUT"))
+        assertEquals(0.0, counterFor(registry, "success", "RUT"))
+    }
+
+    @Test
+    fun `runs are counted separately per codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.incrementSuccessfulRun("RUT")
+        metrics.incrementSuccessfulRun("RUT")
+        metrics.incrementSuccessfulRun("ATB")
+
+        assertEquals(2.0, counterFor(registry, "success", "RUT"))
+        assertEquals(1.0, counterFor(registry, "success", "ATB"))
+    }
+
+    @Test
+    fun `null or blank codespace is recorded as unknown`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.incrementSuccessfulRun(null)
+        metrics.incrementFailedRun("  ")
+
+        assertEquals(1.0, counterFor(registry, "success", "unknown"))
+        assertEquals(1.0, counterFor(registry, "failed", "unknown"))
+    }
+
+    @Test
+    fun `recordSuccessfulRunDuration records the duration tagged by codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.recordSuccessfulRunDuration("RUT", Duration.ofMillis(1500))
+
+        assertEquals(1L, durationCount(registry, "RUT"))
+        assertEquals(1500.0, durationTotalMillis(registry, "RUT"), 1.0)
+    }
+
+    @Test
+    fun `durations are recorded and accumulated separately per codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.recordSuccessfulRunDuration("RUT", Duration.ofMillis(1000))
+        metrics.recordSuccessfulRunDuration("RUT", Duration.ofMillis(2000))
+        metrics.recordSuccessfulRunDuration("ATB", Duration.ofMillis(500))
+
+        assertEquals(2L, durationCount(registry, "RUT"))
+        assertEquals(3000.0, durationTotalMillis(registry, "RUT"), 1.0)
+        assertEquals(1L, durationCount(registry, "ATB"))
+        assertEquals(500.0, durationTotalMillis(registry, "ATB"), 1.0)
+    }
+
+    @Test
+    fun `null or blank codespace duration is recorded as unknown`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.recordSuccessfulRunDuration(null, Duration.ofMillis(100))
+
+        assertEquals(1L, durationCount(registry, "unknown"))
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/RecordFilterRunProcessorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/RecordFilterRunProcessorTest.kt
@@ -1,0 +1,50 @@
+package org.entur.ror.ashur.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.camel.impl.DefaultCamelContext
+import org.apache.camel.support.DefaultExchange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RecordFilterRunProcessorTest {
+    private fun count(registry: SimpleMeterRegistry, status: String, codespace: String): Double =
+        registry.find(FilterMetrics.RUNS_METRIC_NAME)
+            .tags("status", status, "codespace", codespace)
+            .counter()
+            ?.count() ?: 0.0
+
+    @Test
+    fun `records a successful run for the codespace on the exchange`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+        val exchange = DefaultExchange(DefaultCamelContext())
+        exchange.getIn().setHeader("codespace", "RUT")
+
+        RecordFilterRunProcessor(metrics, successful = true).process(exchange)
+
+        assertEquals(1.0, count(registry, "success", "RUT"))
+    }
+
+    @Test
+    fun `records a failed run for the codespace on the exchange`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+        val exchange = DefaultExchange(DefaultCamelContext())
+        exchange.getIn().setHeader("codespace", "ATB")
+
+        RecordFilterRunProcessor(metrics, successful = false).process(exchange)
+
+        assertEquals(1.0, count(registry, "failed", "ATB"))
+    }
+
+    @Test
+    fun `records unknown when the codespace header is missing`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+        val exchange = DefaultExchange(DefaultCamelContext())
+
+        RecordFilterRunProcessor(metrics, successful = true).process(exchange)
+
+        assertEquals(1.0, count(registry, "success", "unknown"))
+    }
+}


### PR DESCRIPTION
Emit per-codespace application metrics from the filtering pipeline, exposed on the existing `/actuator/prometheus` endpoint:

- `ashur_filter_runs_total` — counter of finished runs, incremented on the succeeded/failed status routes
- `ashur_filter_duration_seconds` — timer for successful runs only, measured over the full handleFilterRequestForFile pipeline

Both carry the codespace label, so dashboards can group per codespace and aggregate across codespaces from the same series