### PR TITLE
Fixes increase() undercounting

### DIFF
--- a/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
@@ -7,6 +7,7 @@ import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.getCodespace
 import org.entur.ror.ashur.getCorrelationId
 import org.entur.ror.ashur.metrics.FilterMetrics
+import org.entur.ror.ashur.metrics.InitializeFilterRunMetricsProcessor
 import org.entur.ror.ashur.metrics.RecordFilterRunProcessor
 import org.entur.ror.ashur.report.CreateFilteringReportProcessor
 import org.entur.ror.ashur.toPubsubMessage
@@ -39,6 +40,7 @@ class NetexFilterRouteBuilder(
                 exchange.message.setHeader(Constants.FILTERING_PROFILE_HEADER,
                     pubsubMessage.attributesMap[Constants.FILTERING_PROFILE_HEADER])
             })
+            .process(InitializeFilterRunMetricsProcessor(filterMetrics))
             .to("direct:filterProcessingStatusStarted")
             .to("direct:filterProcessingQueue")
             .to("direct:filterProcessingStatusSucceeded")

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
@@ -25,6 +25,19 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
 
     fun incrementFailedRun(codespace: String?) = increment(STATUS_FAILED, codespace)
 
+    /**
+     * Registers the success and failed run counters for [codespace] at zero, without incrementing them.
+     *
+     * The counters are otherwise created lazily on their first increment (already at value 1), so a
+     * Prometheus scrape never observes the `0 -> 1` step and `rate()`/`increase()` silently drop the
+     * first run of each (codespace, pod) series. Calling this at run start exposes the `0` baseline so
+     * the first run becomes countable. Registration is idempotent, so it never resets an existing count.
+     */
+    fun initializeRunCounters(codespace: String?) {
+        runCounter(STATUS_SUCCESS, codespace)
+        runCounter(STATUS_FAILED, codespace)
+    }
+
     fun recordSuccessfulRunDuration(codespace: String?, duration: Duration) {
         Timer.builder(DURATION_METRIC_NAME)
             .tag("codespace", codespace.orUnknown())
@@ -32,13 +45,13 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
             .record(duration)
     }
 
-    private fun increment(status: String, codespace: String?) {
+    private fun increment(status: String, codespace: String?) = runCounter(status, codespace).increment()
+
+    private fun runCounter(status: String, codespace: String?): Counter =
         Counter.builder(RUNS_METRIC_NAME)
             .tag("status", status)
             .tag("codespace", codespace.orUnknown())
             .register(meterRegistry)
-            .increment()
-    }
 
     private fun String?.orUnknown(): String = this?.takeIf { it.isNotBlank() } ?: UNKNOWN_CODESPACE
 

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/InitializeFilterRunMetricsProcessor.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/InitializeFilterRunMetricsProcessor.kt
@@ -1,0 +1,41 @@
+package org.entur.ror.ashur.metrics
+
+import org.apache.camel.Exchange
+import org.apache.camel.Processor
+import org.slf4j.LoggerFactory
+
+/**
+ * Camel processor that pre-registers the run counters for the exchange's codespace at run start.
+ *
+ * Reads the `codespace` routing header (set at route entry) and asks [FilterMetrics] to register the
+ * success and failed counters at zero, so a Prometheus scrape observes the `0` baseline before the
+ * first run finishes. Without this, `rate()`/`increase()` cannot see the first `0 -> 1` increment and
+ * drop the first run of each (codespace, pod) series.
+ *
+ * @param filterMetrics the metrics component to initialise the counters on.
+ */
+class InitializeFilterRunMetricsProcessor(
+    private val filterMetrics: FilterMetrics,
+) : Processor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun process(exchange: Exchange) {
+        val codespace = exchange.getIn().getHeader(CODESPACE_HEADER, String::class.java)
+        // Never let a metrics side-effect fail the filter run: this runs on the main route before
+        // status STARTED, so a thrown exception would be handled as a FAILED run.
+        try {
+            filterMetrics.initializeRunCounters(codespace)
+            logger.debug("Initialised filter-run metric counters at 0 for codespace: {}", codespace ?: "unknown")
+        } catch (e: Exception) {
+            logger.warn(
+                "Failed to initialise filter-run metric counters for codespace: {}; continuing the run",
+                codespace ?: "unknown",
+                e,
+            )
+        }
+    }
+
+    companion object {
+        const val CODESPACE_HEADER = "codespace"
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
@@ -5,6 +5,7 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class FilterMetricsTest {
     private fun counterFor(
@@ -74,6 +75,39 @@ class FilterMetricsTest {
 
         assertEquals(1.0, counterFor(registry, "success", "unknown"))
         assertEquals(1.0, counterFor(registry, "failed", "unknown"))
+    }
+
+    @Test
+    fun `initializeRunCounters registers success and failed counters at zero`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.initializeRunCounters("RUT")
+
+        assertNotNull(
+            registry.find(FilterMetrics.RUNS_METRIC_NAME)
+                .tags("status", "success", "codespace", "RUT").counter(),
+            "success counter must be registered so a scrape sees the 0 baseline",
+        )
+        assertNotNull(
+            registry.find(FilterMetrics.RUNS_METRIC_NAME)
+                .tags("status", "failed", "codespace", "RUT").counter(),
+            "failed counter must be registered so a scrape sees the 0 baseline",
+        )
+        assertEquals(0.0, counterFor(registry, "success", "RUT"))
+        assertEquals(0.0, counterFor(registry, "failed", "RUT"))
+    }
+
+    @Test
+    fun `initializeRunCounters does not reset an existing count`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.incrementSuccessfulRun("RUT")
+        metrics.initializeRunCounters("RUT")
+
+        assertEquals(1.0, counterFor(registry, "success", "RUT"))
+        assertEquals(0.0, counterFor(registry, "failed", "RUT"))
     }
 
     @Test

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/InitializeFilterRunMetricsProcessorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/InitializeFilterRunMetricsProcessorTest.kt
@@ -1,0 +1,61 @@
+package org.entur.ror.ashur.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.apache.camel.impl.DefaultCamelContext
+import org.apache.camel.support.DefaultExchange
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class InitializeFilterRunMetricsProcessorTest {
+    private fun counter(registry: SimpleMeterRegistry, status: String, codespace: String): Counter? =
+        registry.find(FilterMetrics.RUNS_METRIC_NAME)
+            .tags("status", status, "codespace", codespace)
+            .counter()
+
+    @Test
+    fun `registers success and failed counters at zero for the codespace on the exchange`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+        val exchange = DefaultExchange(DefaultCamelContext())
+        exchange.getIn().setHeader("codespace", "RUT")
+
+        InitializeFilterRunMetricsProcessor(metrics).process(exchange)
+
+        assertNotNull(counter(registry, "success", "RUT"))
+        assertNotNull(counter(registry, "failed", "RUT"))
+        assertEquals(0.0, counter(registry, "success", "RUT")?.count())
+        assertEquals(0.0, counter(registry, "failed", "RUT")?.count())
+    }
+
+    @Test
+    fun `registers counters under unknown when the codespace header is missing`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+        val exchange = DefaultExchange(DefaultCamelContext())
+
+        InitializeFilterRunMetricsProcessor(metrics).process(exchange)
+
+        assertNotNull(counter(registry, "success", "unknown"))
+        assertNotNull(counter(registry, "failed", "unknown"))
+    }
+
+    @Test
+    fun `does not fail the run when counter initialisation throws`() {
+        val metrics = mock<FilterMetrics>()
+        doThrow(RuntimeException("meter registry unavailable"))
+            .whenever(metrics).initializeRunCounters(any())
+        val exchange = DefaultExchange(DefaultCamelContext())
+        exchange.getIn().setHeader("codespace", "RUT")
+
+        assertDoesNotThrow {
+            InitializeFilterRunMetricsProcessor(metrics).process(exchange)
+        }
+    }
+}


### PR DESCRIPTION
`ashur_filter_runs_total` was created lazily on first increment, resulting in the first run of every (codespace, pod) becoming silently dropped in the PromQL query result. This issue would reccur on every deploy, because new pods create brand-new series that again start at 1 — so dashboards consistently undercounted successful/failed runs.

The fix registers counters at 0 when a run starts. Once the 0 baseline is scraped, increase() can observe the first 0 -> 1 and counts it.