### PR TITLE
Adds original ServiceJourney count metric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <google-pubsub.version>1.150.2</google-pubsub.version>
         <protobuf-java.version>4.33.2</protobuf-java.version>
         <gax.version>2.80.0</gax.version>
-        <netex-tools.version>0.0.46</netex-tools.version>
+        <netex-tools.version>0.0.50</netex-tools.version>
         <camel.version>4.20.0</camel.version>
         <slf4j.version>2.0.17</slf4j.version>
         <mockito-kotlin.version>6.3.0</mockito-kotlin.version>

--- a/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
@@ -1,8 +1,8 @@
 package org.entur.ror.ashur.filter
 
+import org.entur.netex.tools.lib.app.FilterNetexApp
 import org.entur.netex.tools.lib.config.FilterConfig
 import org.entur.netex.tools.lib.report.FilterReport
-import org.entur.netex.tools.pipeline.app.FilterNetexApp
 import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.exceptions.InvalidZipFileException
 import org.entur.ror.ashur.exceptions.NoJourneysInNetexFileException
@@ -283,7 +283,11 @@ class FilterService(
 
         // Reached only when the run succeeded; failures throw before this point.
         filterMetrics.recordSuccessfulRunDuration(codespace, Duration.ofNanos(System.nanoTime() - runStartNanos))
-        filterMetrics.setServiceJourneysKept(codespace, filterReport.getNumberOfElementsOfType("ServiceJourney"))
+        filterMetrics.setServiceJourneysKept(
+            codespace,
+            keptCount = filterReport.getNumberOfElementsOfType("ServiceJourney"),
+            originalCount = filterReport.originalEntityTypeCount["ServiceJourney"] ?: 0,
+        )
 
         return FilterResult(
             filteredZipFilePath = filteredZipFileName,

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
@@ -36,6 +36,7 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
     // A gauge only keeps a weak reference to the value behind it, so we hold that value ourselves
     // (one number per codespace, per gauge) and overwrite it on each run.
     private val serviceJourneysKeptValues = ConcurrentHashMap<String, AtomicLong>()
+    private val serviceJourneysOriginalValues = ConcurrentHashMap<String, AtomicLong>()
     private val serviceJourneysKeptUpdatedMs = ConcurrentHashMap<String, AtomicLong>()
 
     fun incrementSuccessfulRun(codespace: String?) = increment(STATUS_SUCCESS, codespace)
@@ -62,9 +63,10 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
      *
      * Both gauges are created the first time a codespace appears, then just updated in place on later runs.
      */
-    fun setServiceJourneysKept(codespace: String?, count: Int, epochMillis: Long = System.currentTimeMillis()) {
+    fun setServiceJourneysKept(codespace: String?, keptCount: Int, originalCount: Int, epochMillis: Long = System.currentTimeMillis()) {
         val resolvedCodespace = codespace.orUnknown()
-        gaugeHolder(serviceJourneysKeptValues, SERVICE_JOURNEYS_KEPT_METRIC_NAME, resolvedCodespace).set(count.toLong())
+        gaugeHolder(serviceJourneysKeptValues, SERVICE_JOURNEYS_KEPT_METRIC_NAME, resolvedCodespace).set(keptCount.toLong())
+        gaugeHolder(serviceJourneysOriginalValues, SERVICE_JOURNEYS_ORIGINAL_METRIC_NAME, resolvedCodespace).set(originalCount.toLong())
         gaugeHolder(serviceJourneysKeptUpdatedMs, SERVICE_JOURNEYS_KEPT_UPDATED_MS_METRIC_NAME, resolvedCodespace)
             .set(epochMillis)
     }
@@ -100,6 +102,7 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
         const val RUNS_METRIC_NAME = "ashur.filter.runs"
         const val DURATION_METRIC_NAME = "ashur.filter.duration"
         const val SERVICE_JOURNEYS_KEPT_METRIC_NAME = "ashur.service.journeys.kept"
+        const val SERVICE_JOURNEYS_ORIGINAL_METRIC_NAME = "ashur.service.journeys.original"
         const val SERVICE_JOURNEYS_KEPT_UPDATED_MS_METRIC_NAME = "ashur.service.journeys.kept.updated.ms"
         const val STATUS_SUCCESS = "success"
         const val STATUS_FAILED = "failed"

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
@@ -41,6 +41,12 @@ class FilterMetricsTest {
             .gauge()
             ?.value()
 
+    private fun serviceJourneysOriginal(registry: SimpleMeterRegistry, codespace: String): Double? =
+        registry.find(FilterMetrics.SERVICE_JOURNEYS_ORIGINAL_METRIC_NAME)
+            .tags("codespace", codespace)
+            .gauge()
+            ?.value()
+
     @Test
     fun `incrementSuccessfulRun records one run tagged status=success and codespace`() {
         val registry = SimpleMeterRegistry()
@@ -129,7 +135,7 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept("RUT", 42)
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
 
         assertEquals(42.0, serviceJourneysKept(registry, "RUT"))
     }
@@ -139,8 +145,8 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept("RUT", 42)
-        metrics.setServiceJourneysKept("RUT", 40)
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
+        metrics.setServiceJourneysKept("RUT", keptCount = 40, originalCount = 95)
 
         assertEquals(40.0, serviceJourneysKept(registry, "RUT"))
     }
@@ -150,8 +156,8 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept("RUT", 42)
-        metrics.setServiceJourneysKept("ATB", 7)
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
+        metrics.setServiceJourneysKept("ATB", keptCount = 7, originalCount = 10)
 
         assertEquals(42.0, serviceJourneysKept(registry, "RUT"))
         assertEquals(7.0, serviceJourneysKept(registry, "ATB"))
@@ -162,7 +168,7 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept(null, 5)
+        metrics.setServiceJourneysKept(null, keptCount = 5, originalCount = 10)
 
         assertEquals(5.0, serviceJourneysKept(registry, "unknown"))
     }
@@ -172,7 +178,7 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept("RUT", 42, epochMillis = 1_761_000_000_123L)
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100, epochMillis = 1_761_000_000_123L)
 
         assertEquals(1_761_000_000_123.0, serviceJourneysKeptUpdatedMs(registry, "RUT"))
     }
@@ -182,9 +188,52 @@ class FilterMetricsTest {
         val registry = SimpleMeterRegistry()
         val metrics = FilterMetrics(registry)
 
-        metrics.setServiceJourneysKept("RUT", 42, epochMillis = 1000L)
-        metrics.setServiceJourneysKept("RUT", 40, epochMillis = 2000L)
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100, epochMillis = 1000L)
+        metrics.setServiceJourneysKept("RUT", keptCount = 40, originalCount = 95, epochMillis = 2000L)
 
         assertEquals(2000.0, serviceJourneysKeptUpdatedMs(registry, "RUT"))
+    }
+
+    @Test
+    fun `setServiceJourneysKept registers a gauge for the original count tagged by codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
+
+        assertEquals(100.0, serviceJourneysOriginal(registry, "RUT"))
+    }
+
+    @Test
+    fun `setServiceJourneysKept replaces the original count on a later run`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
+        metrics.setServiceJourneysKept("RUT", keptCount = 40, originalCount = 95)
+
+        assertEquals(95.0, serviceJourneysOriginal(registry, "RUT"))
+    }
+
+    @Test
+    fun `original counts are tracked separately per codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.setServiceJourneysKept("RUT", keptCount = 42, originalCount = 100)
+        metrics.setServiceJourneysKept("ATB", keptCount = 7, originalCount = 10)
+
+        assertEquals(100.0, serviceJourneysOriginal(registry, "RUT"))
+        assertEquals(10.0, serviceJourneysOriginal(registry, "ATB"))
+    }
+
+    @Test
+    fun `null or blank codespace original count is recorded as unknown`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.setServiceJourneysKept(null, keptCount = 5, originalCount = 10)
+
+        assertEquals(10.0, serviceJourneysOriginal(registry, "unknown"))
     }
 }


### PR DESCRIPTION
* Creates a new metric for keeping track of the number of ServiceJourney entities in the original datasets - before filtering.
* Also upgrades netex-tools dependency to 0.0.50.