### PR TITLE
Log build version at startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
                             <goal>repackage</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -91,6 +97,26 @@
                 <version>1.6.0</version>
                 <configuration>
                     <mainClass>MainKt</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>10.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- Keep the build green if .git is absent (e.g. jar rebuilt outside a checkout);
+                         commit fields simply fall back to "unknown" at runtime. -->
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <!-- Writes target/classes/git.properties, which Spring Boot reads into GitProperties. -->
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <!-- Writes target/classes/git.properties, which Spring Boot reads into GitProperties. -->
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!-- Allowlist only the fields VersionLogger reads, so no committer emails, build
+                         host, remote URL or commit messages get baked into the shipped jar. -->
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                    </includeOnlyProperties>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
@@ -1,0 +1,47 @@
+package org.entur.ror.ashur.config
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.boot.info.BuildProperties
+import org.springframework.boot.info.GitProperties
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Logs the running build/git version once, when the application is ready.
+ *
+ * The [BuildProperties] and [GitProperties] beans are auto-configured by Spring Boot from
+ * `META-INF/build-info.properties` and `git.properties`, generated at build time by the
+ * spring-boot-maven-plugin `build-info` goal and the git-commit-id-maven-plugin respectively.
+ * They are injected via [ObjectProvider] so a run without those files (e.g. an IDE run that
+ * skipped the Maven build) logs "unknown" instead of failing to start.
+ *
+ * [BuildProperties.getTime] is the instant the artifact was built (i.e. when the Docker image's
+ * jar was produced in CI); it is rendered in Norwegian local time for readability.
+ */
+@Component
+class VersionLogger(
+    private val buildProperties: ObjectProvider<BuildProperties>,
+    private val gitProperties: ObjectProvider<GitProperties>,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val buildTimeFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("Europe/Oslo"))
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun logVersion() {
+        val build = buildProperties.ifAvailable
+        val git = gitProperties.ifAvailable
+        val imageBuiltAt = build?.time?.let(buildTimeFormatter::format) ?: "unknown"
+        logger.info(
+            "Ashur started — commit={}, branch={}, image built {} (Norway time)",
+            git?.shortCommitId ?: "unknown",
+            git?.branch ?: "unknown",
+            imageBuiltAt,
+        )
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.boot.info.BuildProperties
 import org.springframework.boot.info.GitProperties
+import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
@@ -16,12 +17,14 @@ import org.springframework.stereotype.Component
  * The [BuildProperties] and [GitProperties] beans are auto-configured by Spring Boot from
  * `META-INF/build-info.properties` and `git.properties`, generated at build time by the
  * spring-boot-maven-plugin `build-info` goal and the git-commit-id-maven-plugin respectively.
- * They are injected via [ObjectProvider] so a run without those files (e.g. an IDE run that
- * skipped the Maven build) logs "unknown" instead of failing to start.
+ *
+ * Restricted to the `gcp` profile (the deployed dev/tst/prd environments), where the metadata
+ * reflects the CI-built jar that is actually running.
  *
  * [BuildProperties.getTime] is the instant the artifact was built (i.e. when the Docker image's
  * jar was produced in CI); it is rendered in Norwegian local time for readability.
  */
+@Profile("gcp")
 @Component
 class VersionLogger(
     private val buildProperties: ObjectProvider<BuildProperties>,

--- a/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/config/VersionLogger.kt
@@ -41,7 +41,7 @@ class VersionLogger(
         val git = gitProperties.ifAvailable
         val imageBuiltAt = build?.time?.let(buildTimeFormatter::format) ?: "unknown"
         logger.info(
-            "Ashur started — commit={}, branch={}, image built {} (Norway time)",
+            "Ashur started: commit={}, branch={}, image built {} (Norway time)",
             git?.shortCommitId ?: "unknown",
             git?.branch ?: "unknown",
             imageBuiltAt,


### PR DESCRIPTION
Adds a VersionLogger that logs the running git commit, branch, and image build time once the application is ready, so it's easy to tell which build a running pod is on. The commit hash is the meaningful identifier.