### PR TITLE
Upgrade Camel to 4.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <protobuf-java.version>4.33.2</protobuf-java.version>
         <gax.version>2.81.0</gax.version>
         <netex-tools.version>0.0.50</netex-tools.version>
-        <camel.version>4.20.0</camel.version>
+        <camel.version>4.21.0</camel.version>
         <slf4j.version>2.0.17</slf4j.version>
         <mockito-kotlin.version>6.3.0</mockito-kotlin.version>
         <spring-boot.version>4.0.6</spring-boot.version>

--- a/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
@@ -34,11 +34,13 @@ open class BaseRouteBuilder(
         onException(AshurException::class.java)
             .handled(true)
             .process { exchange ->
-                val exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, AshurException::class.java)
-                if (exception.errorCode != null) {
+                val errorCode = exchange
+                    .getProperty(Exchange.EXCEPTION_CAUGHT, AshurException::class.java)
+                    ?.errorCode
+                if (errorCode != null) {
                     exchange.addPubsubAttribute(
                         Constants.FILTERING_ERROR_CODE_HEADER,
-                        exception.errorCode
+                        errorCode
                     )
                 }
             }

--- a/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
@@ -63,10 +63,9 @@ class NetexFilterRouteBuilder(
             .process(RecordFilterRunProcessor(filterMetrics, successful = true))
             .process(createFilteringReportProcessor)
             .process { exchange ->
-                exchange.addPubsubAttribute(
-                    Constants.FILTERED_NETEX_FILE_PATH_HEADER,
-                    exchange.getIn().getHeader(Constants.FILTERED_NETEX_FILE_PATH_HEADER, String::class.java)
-                )
+                exchange.getIn()
+                    .getHeader(Constants.FILTERED_NETEX_FILE_PATH_HEADER, String::class.java)
+                    ?.let { exchange.addPubsubAttribute(Constants.FILTERED_NETEX_FILE_PATH_HEADER, it) }
             }
             .log(LoggingLevel.INFO, "Publishing processing status SUCCEEDED for codespace: \${header.codespace}")
             .to("google-pubsub:$mardukProjectId:$statusTopic")

--- a/src/main/kotlin/org/entur/ror/ashur/camel/SetFilteringStatusProcessor.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/SetFilteringStatusProcessor.kt
@@ -3,6 +3,7 @@ package org.entur.ror.ashur.camel
 import org.apache.camel.Exchange
 import org.apache.camel.Processor
 import org.entur.ror.ashur.Constants
+import org.entur.ror.ashur.addPubsubAttribute
 
 /**
  * SetFilteringStatusProcessor is a Camel processor that sets the filtering status
@@ -12,16 +13,9 @@ import org.entur.ror.ashur.Constants
  */
 class SetFilteringStatusProcessor(val status: String): Processor {
     override fun process(exchange: Exchange) {
-        val existingAttributes = exchange
-            .getIn()
-            .getHeader("CamelGooglePubsubAttributes", Map::class.java)
-            .toMutableMap()
-        existingAttributes[Constants.FILTERING_REPORT_STATUS_HEADER] = status
-        val filteringProfile = existingAttributes[Constants.FILTERING_PROFILE_HEADER]?.toString()
-            ?: exchange.getIn().getHeader(Constants.FILTERING_PROFILE_HEADER, String::class.java)
-        if (filteringProfile != null) {
-            existingAttributes[Constants.FILTERING_PROFILE_HEADER] = filteringProfile
-        }
-        exchange.getIn().setHeader("CamelGooglePubsubAttributes", existingAttributes)
+        exchange.addPubsubAttribute(Constants.FILTERING_REPORT_STATUS_HEADER, status)
+        exchange.getIn()
+            .getHeader(Constants.FILTERING_PROFILE_HEADER, String::class.java)
+            ?.let { exchange.addPubsubAttribute(Constants.FILTERING_PROFILE_HEADER, it) }
     }
 }

--- a/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
@@ -3,6 +3,7 @@ package org.entur.ror.ashur.camel
 import io.micrometer.core.instrument.MeterRegistry
 import org.apache.camel.CamelContext
 import org.apache.camel.ConsumerTemplate
+import org.apache.camel.Exchange
 import org.apache.camel.ProducerTemplate
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest
 import tools.jackson.module.kotlin.jacksonObjectMapper
@@ -88,6 +89,14 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     fun pathOfFilteredFile(fileName: String, correlationId: String) = "${testCodespace}/${correlationId}/filtered_${fileName}"
     fun pathOfFilteringReport(correlationId: String) = "reports/${testCodespace}/filtering-report-${correlationId}.json"
 
+    private fun receiveStatusMessage(timeoutMillis: Long): Exchange {
+        val uri = "google-pubsub:${appConfig.gcp.mardukProjectId}:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true"
+        return assertNotNull(
+            consumerTemplate.receive(uri, timeoutMillis),
+            "no status message on ${Constants.FILTER_NETEX_FILE_STATUS_TOPIC} within ${timeoutMillis}ms",
+        )
+    }
+
     fun fileExistsInAshurInternalBucket(filePath: String): Boolean {
         val target = File("${appConfig.local.blobstorePath}/${appConfig.gcp.ashurBucketName}/$filePath")
         return target.exists()
@@ -120,7 +129,6 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     @Test
     fun `test filter route processes message successfully`() {
         copyTestZipFileToMardukTestBucket()
-        val mardukProjectId = appConfig.gcp.mardukProjectId
         val correlationId = "success-correlation-id"
         val successRunsBefore = runCount(FilterMetrics.STATUS_SUCCESS)
         val durationRunsBefore = durationRunCount()
@@ -129,15 +137,9 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
             netexFilePath = "testfile.zip",
             correlationId = correlationId,
         )
-        val startedMessage = consumerTemplate.receive(
-            "google-pubsub:$mardukProjectId:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true",
-            5000
-        )
+        val startedMessage = receiveStatusMessage(5000)
 
-        val successMessage = consumerTemplate.receive(
-            "google-pubsub:$mardukProjectId:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true",
-            10000
-        )
+        val successMessage = receiveStatusMessage(10000)
 
         assertEquals(correlationId, startedMessage.toPubsubMessage().getCorrelationId())
         assertEquals(correlationId, successMessage.toPubsubMessage().getCorrelationId())
@@ -170,22 +172,15 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
 
     @Test
     fun `test filter route processes message but fails because file does not exist`() {
-        val mardukProjectId = appConfig.gcp.mardukProjectId
         val failingCorrelationId = "failing-correlation-id"
         val failedRunsBefore = runCount(FilterMetrics.STATUS_FAILED)
         val durationRunsBefore = durationRunCount()
 
         sendFilterMessageToPubsub(netexFilePath = "unknown-file.zip", correlationId = failingCorrelationId)
 
-        val startedMessage = consumerTemplate.receive(
-            "google-pubsub:$mardukProjectId:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true",
-            5000
-        )
+        val startedMessage = receiveStatusMessage(5000)
 
-        val failedMessage = consumerTemplate.receive(
-            "google-pubsub:$mardukProjectId:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true",
-            10000
-        )
+        val failedMessage = receiveStatusMessage(10000)
 
         assertEquals(failingCorrelationId, startedMessage.toPubsubMessage().getCorrelationId())
         assertEquals(failingCorrelationId, failedMessage.toPubsubMessage().getCorrelationId())


### PR DESCRIPTION
4.20.0 lacks the pubsub consumer's in-flight drain that 4.18.3 had, so a filter job still running on redeploy has its thread interrupted and publishes no status. Pub/Sub redelivers the message. 4.21.0 restores the drain, and it covers the synchronousPull path used here.

4.21.0 marks camel-api @NullMarked, so getProperty and getHeader are nullable to Kotlin. The succeeded path now skips the filtered-file attribute when the header is absent instead of tripping Kotlin's non-null parameter check, and SetFilteringStatusProcessor takes the profile from the header only rather than preferring the attributes map.