### PR TITLE
Add redelivery guard to avoid duplicate filter processing

### DIFF
--- a/helm/ashur/env/values-kub-ent-dev.yaml
+++ b/helm/ashur/env/values-kub-ent-dev.yaml
@@ -17,6 +17,9 @@ configmap:
       inputPath: /tmp/netex-data/input
       outputPath: /tmp/netex-data/output
       cleanupEnabled: true
+    redeliveryGuard:
+      enabled: true
+      ttlSeconds: 1200
 
   camel:
     component:

--- a/helm/ashur/env/values-kub-ent-prd.yaml
+++ b/helm/ashur/env/values-kub-ent-prd.yaml
@@ -17,6 +17,9 @@ configmap:
       inputPath: /tmp/netex-data/input
       outputPath: /tmp/netex-data/output
       cleanupEnabled: true
+    redeliveryGuard:
+      enabled: true
+      ttlSeconds: 1200
 
   camel:
     component:

--- a/helm/ashur/env/values-kub-ent-tst.yaml
+++ b/helm/ashur/env/values-kub-ent-tst.yaml
@@ -17,6 +17,9 @@ configmap:
       inputPath: /tmp/netex-data/input
       outputPath: /tmp/netex-data/output
       cleanupEnabled: true
+    redeliveryGuard:
+      enabled: true
+      ttlSeconds: 1200
 
   camel:
     component:

--- a/helm/ashur/templates/configmap.yaml
+++ b/helm/ashur/templates/configmap.yaml
@@ -20,7 +20,10 @@ data:
     ashur.netex.input-path={{ .Values.configmap.ashur.netex.inputPath }}
     ashur.netex.output-path={{ .Values.configmap.ashur.netex.outputPath }}
     ashur.netex.cleanup-enabled={{ .Values.configmap.ashur.netex.cleanupEnabled }}
-    
+
+    ashur.redelivery-guard.enabled={{ .Values.configmap.ashur.redeliveryGuard.enabled }}
+    ashur.redelivery-guard.ttl-seconds={{ .Values.configmap.ashur.redeliveryGuard.ttlSeconds }}
+
     camel.component.google-pubsub.projectId={{ .Values.configmap.camel.component.googlePubsub.projectId }}
     
     spring.profiles.active=gcp

--- a/src/main/kotlin/org/entur/ror/ashur/Constants.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/Constants.kt
@@ -22,4 +22,7 @@ object Constants {
     val FILTERING_ERROR_CODE_HEADER = "FilteringErrorCode"
 
     val NO_JOURNEYS_IN_NETEX_DATASET_ERROR_CODE = "NO_JOURNEYS_IN_NETEX_DATASET"
+
+    val GUARD_DECISION_HEADER = "AshurRedeliveryGuardDecision"
+    val GUARD_DECISION_SKIP = "SKIP"
 }

--- a/src/main/kotlin/org/entur/ror/ashur/Extensions.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/Extensions.kt
@@ -9,6 +9,14 @@ import org.entur.ror.ashur.filter.FilterProfile
 import java.io.File
 import java.time.LocalDateTime
 
+/**
+ * The object path, within the Ashur internal + exchange buckets, of the filtered output for a
+ * request. This is the redelivery guard's durable "done-signal", and it MUST match exactly the path
+ * [org.entur.ror.ashur.filter.FilterService] uploads to. Derivable purely from message attributes.
+ */
+fun filteredOutputObjectPath(codespace: String, correlationId: String, netexFileName: String): String =
+    "$codespace/$correlationId/filtered_${File(netexFileName).name}"
+
 fun File.createFileWithDirectories(): File {
     if (!this.exists()) {
         if (!this.parentFile.exists()) {

--- a/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
@@ -7,6 +7,7 @@ import org.entur.ror.ashur.Constants
 import org.entur.ror.ashur.addPubsubAttribute
 import org.entur.ror.ashur.config.AppConfig
 import org.entur.ror.ashur.exceptions.AshurException
+import org.entur.ror.ashur.exceptions.ClaimHeldException
 import org.entur.ror.ashur.metrics.FilterMetrics
 import org.entur.ror.ashur.metrics.RecordFilterRunProcessor
 import org.entur.ror.ashur.report.CreateFilteringReportProcessor
@@ -30,6 +31,15 @@ open class BaseRouteBuilder(
 
         interceptSendToEndpoint("google-pubsub:*")
             .process(LogOutboundPubsubMessageProcessor())
+
+        // A bounce is NOT a failure: do not publish FAILED, and handled(false) lets the exception
+        // propagate so the Pub/Sub consumer nacks the message and the server redelivers it later.
+        onException(ClaimHeldException::class.java)
+            .handled(false)
+            .log(
+                LoggingLevel.INFO,
+                "Redelivery guard bounced message from Pub/Sub topic $filterSubscription (nack for redelivery): \${exception.message}",
+            )
 
         onException(AshurException::class.java)
             .handled(true)

--- a/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilder.kt
@@ -23,6 +23,7 @@ class NetexFilterRouteBuilder(
     netexFilterMessageProcessor: NetexFilterMessageProcessor,
     createFilteringReportProcessor: CreateFilteringReportProcessor,
     filterMetrics: FilterMetrics,
+    private val redeliveryGuardProcessor: RedeliveryGuardProcessor,
 ) : BaseRouteBuilder(appConfig, netexFilterMessageProcessor, createFilteringReportProcessor, filterMetrics) {
     override fun configure() {
         super.configure()
@@ -39,6 +40,14 @@ class NetexFilterRouteBuilder(
                 exchange.message.setHeader(Constants.FILTERING_PROFILE_HEADER,
                     pubsubMessage.attributesMap[Constants.FILTERING_PROFILE_HEADER])
             })
+            // Idempotency guard: runs before STARTED so a skipped/bounced redelivery emits no status.
+            // SKIP -> stop (ack, no re-processing); BOUNCE -> ClaimHeldException (nack); PROCESS -> continue.
+            .process(redeliveryGuardProcessor)
+            .choice()
+                .`when`(header(Constants.GUARD_DECISION_HEADER).isEqualTo(Constants.GUARD_DECISION_SKIP))
+                    .log(LoggingLevel.INFO, "Redelivery guard: skipping already-completed request for codespace: \${header.codespace}")
+                    .stop()
+            .end()
             .to("direct:filterProcessingStatusStarted")
             .to("direct:filterProcessingQueue")
             .to("direct:filterProcessingStatusSucceeded")

--- a/src/main/kotlin/org/entur/ror/ashur/camel/RedeliveryGuardProcessor.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/RedeliveryGuardProcessor.kt
@@ -1,0 +1,62 @@
+package org.entur.ror.ashur.camel
+
+import org.apache.camel.Exchange
+import org.apache.camel.Processor
+import org.entur.ror.ashur.Constants
+import org.entur.ror.ashur.exceptions.ClaimHeldException
+import org.entur.ror.ashur.filteredOutputObjectPath
+import org.entur.ror.ashur.getCodespace
+import org.entur.ror.ashur.getCorrelationId
+import org.entur.ror.ashur.getNetexFileName
+import org.entur.ror.ashur.pubsub.GuardDecision
+import org.entur.ror.ashur.pubsub.GuardRequest
+import org.entur.ror.ashur.pubsub.RedeliveryGuard
+import org.entur.ror.ashur.toPubsubMessage
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Runs the [RedeliveryGuard] at the very start of the route (before STARTED is published) and
+ * translates its decision into route behavior:
+ * - PROCESS  -> do nothing; the route continues into the normal pipeline.
+ * - SKIP     -> set [Constants.GUARD_DECISION_HEADER]; the route stops (ack) without re-processing.
+ * - BOUNCE   -> throw [ClaimHeldException]; the route nacks so Pub/Sub redelivers later.
+ *
+ * If codespace / correlationId / file handle are missing we degrade to processing (as today) and let
+ * the downstream pipeline handle the malformed message — the guard never introduces a new failure.
+ */
+@Component
+class RedeliveryGuardProcessor(
+    private val redeliveryGuard: RedeliveryGuard,
+) : Processor {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun process(exchange: Exchange) {
+        val message = exchange.toPubsubMessage()
+        val codespace = message.getCodespace()
+        val correlationId = message.getCorrelationId()
+        val fileName = message.getNetexFileName()
+
+        if (codespace == null || correlationId == null || fileName == null) {
+            logger.warn(
+                "Redelivery guard: missing attribute(s) (codespace={}, correlationId={}, fileName={}); skipping guard and processing.",
+                codespace, correlationId, fileName,
+            )
+            return
+        }
+
+        val request = GuardRequest(
+            codespace = codespace,
+            correlationId = correlationId,
+            outputPath = filteredOutputObjectPath(codespace, correlationId, fileName),
+        )
+
+        when (redeliveryGuard.evaluate(request)) {
+            GuardDecision.PROCESS -> Unit
+            GuardDecision.SKIP -> exchange.getIn().setHeader(Constants.GUARD_DECISION_HEADER, Constants.GUARD_DECISION_SKIP)
+            GuardDecision.BOUNCE -> throw ClaimHeldException(
+                "Request codespace=$codespace correlationId=$correlationId is already being processed; bouncing for redelivery.",
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/config/AppConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/config/AppConfig.kt
@@ -9,6 +9,7 @@ class AppConfig(
     var netex: NetexConfig = NetexConfig(),
     var gcp: GcpConfig = GcpConfig(),
     var local: LocalConfig = LocalConfig(),
+    var redeliveryGuard: RedeliveryGuardConfig = RedeliveryGuardConfig(),
 ) {
     class NetexConfig {
         lateinit var inputPath: String
@@ -26,5 +27,13 @@ class AppConfig(
 
     class LocalConfig {
         lateinit var blobstorePath: String
+    }
+
+    class RedeliveryGuardConfig {
+        /** When false the guard is a complete no-op (every delivery processes as today). */
+        var enabled: Boolean = true
+
+        /** A claim older than this is considered stale (holder presumed dead) and may be taken over. */
+        var ttlSeconds: Long = 1200
     }
 }

--- a/src/main/kotlin/org/entur/ror/ashur/exceptions/Exceptions.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/exceptions/Exceptions.kt
@@ -11,6 +11,13 @@ abstract class AshurException(
 class InvalidZipFileException(message: String): Exception(message)
 class InvalidFilterProfileException(message: String) : Exception(message)
 
+/**
+ * Signals that the request is already claimed by a live holder (a fresh claim, or a lost takeover
+ * race). Deliberately NOT an [AshurException]: it must not be turned into a FAILED status. The route
+ * handles it with `handled(false)`, so the message is nacked and Pub/Sub redelivers it later.
+ */
+class ClaimHeldException(message: String) : Exception(message)
+
 class NoJourneysInNetexFileException(message: String) : AshurException(
     message = message,
     errorCode = Constants.NO_JOURNEYS_IN_NETEX_DATASET_ERROR_CODE,

--- a/src/main/kotlin/org/entur/ror/ashur/file/ClaimStore.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/file/ClaimStore.kt
@@ -1,0 +1,21 @@
+package org.entur.ror.ashur.file
+
+/**
+ * Minimal coordination primitive for the redelivery guard. Backed in production by GCS object
+ * generation preconditions; in tests/local by an in-memory map. Only the three operations the guard
+ * needs are exposed — deliberately narrower than a blob store, and NOT built on [BlobStoreRepository]
+ * because that abstraction cannot express `ifGenerationMatch`.
+ */
+interface ClaimStore {
+    /** Atomically create [name] iff it does not already exist. @return true if we created it. */
+    fun createIfAbsent(name: String, content: ByteArray): Boolean
+
+    /** @return the current content + generation of [name], or null if it does not exist. */
+    fun read(name: String): VersionedClaim?
+
+    /** Atomically overwrite [name] iff its current generation equals [expectedGeneration]. @return true if we won. */
+    fun overwriteIfGeneration(name: String, content: ByteArray, expectedGeneration: Long): Boolean
+}
+
+/** A claim object's bytes together with the generation they were read at. */
+class VersionedClaim(val content: ByteArray, val generation: Long)

--- a/src/main/kotlin/org/entur/ror/ashur/file/GcsClaimStorageConfig.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/file/GcsClaimStorageConfig.kt
@@ -1,0 +1,38 @@
+package org.entur.ror.ashur.file
+
+import com.google.cloud.NoCredentials
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+/**
+ * Raw [Storage] client for the redelivery guard's claim objects. Separate from
+ * [GcsStorageConfig]'s [org.rutebanken.helper.storage.repository.BlobStoreRepository] because the
+ * guard needs generation preconditions the repository abstraction does not expose.
+ */
+@Configuration
+@Profile("gcp")
+open class GcsClaimStorageConfig {
+
+    @Bean("claimStorage")
+    open fun claimStorage(
+        @Value("\${ashur.gcp.ashur-project-id}") projectId: String?,
+    ): Storage {
+        val emulatorHost = System.getenv("STORAGE_EMULATOR_HOST")
+        if (!emulatorHost.isNullOrBlank()) {
+            return StorageOptions.newBuilder()
+                .setHost(emulatorHost)
+                .setProjectId(projectId)
+                .setCredentials(NoCredentials.getInstance())
+                .build()
+                .service
+        }
+        return StorageOptions.newBuilder()
+            .setProjectId(projectId)
+            .build()
+            .service
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/file/GcsClaimStore.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/file/GcsClaimStore.kt
@@ -1,0 +1,53 @@
+package org.entur.ror.ashur.file
+
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageException
+import org.entur.ror.ashur.config.AppConfig
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * GCS-backed [ClaimStore] using object generation preconditions on the internal Ashur bucket:
+ * - create-if-absent via [Storage.BlobTargetOption.doesNotExist] (`ifGenerationMatch=0`),
+ * - compare-and-swap via [Storage.BlobTargetOption.generationMatch].
+ *
+ * A `412 PRECONDITION FAILED` is the *expected* "someone else got there first" signal and is
+ * translated to a boolean; any other [StorageException] is rethrown so the guard can fail open.
+ */
+@Component
+@Profile("gcp")
+class GcsClaimStore(
+    private val storage: Storage,
+    appConfig: AppConfig,
+) : ClaimStore {
+
+    private val bucket: String = appConfig.gcp.ashurBucketName
+
+    private companion object {
+        const val PRECONDITION_FAILED = 412
+        const val CONTENT_TYPE = "application/json"
+    }
+
+    override fun createIfAbsent(name: String, content: ByteArray): Boolean =
+        writeWithPrecondition(name, content, Storage.BlobTargetOption.doesNotExist())
+
+    override fun read(name: String): VersionedClaim? {
+        val blob = storage.get(BlobId.of(bucket, name)) ?: return null
+        return VersionedClaim(blob.getContent(), blob.generation)
+    }
+
+    override fun overwriteIfGeneration(name: String, content: ByteArray, expectedGeneration: Long): Boolean =
+        writeWithPrecondition(name, content, Storage.BlobTargetOption.generationMatch(expectedGeneration))
+
+    private fun writeWithPrecondition(name: String, content: ByteArray, option: Storage.BlobTargetOption): Boolean {
+        val blobInfo = BlobInfo.newBuilder(BlobId.of(bucket, name)).setContentType(CONTENT_TYPE).build()
+        return try {
+            storage.create(blobInfo, content, option)
+            true
+        } catch (e: StorageException) {
+            if (e.code == PRECONDITION_FAILED) false else throw e
+        }
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/file/InMemoryClaimStore.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/file/InMemoryClaimStore.kt
@@ -1,0 +1,48 @@
+package org.entur.ror.ashur.file
+
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+/**
+ * Faithful in-memory [ClaimStore] modelling GCS's atomic create-if-absent and generation-match
+ * semantics. Used as the `local`/`test` bean and directly as the fake in guard unit tests.
+ *
+ * A single Ashur process in local/test has no cross-pod race to coordinate, so this is enough there;
+ * production coordination across the two pods is [GcsClaimStore]'s job.
+ */
+@Component
+@Profile("local", "test")
+class InMemoryClaimStore : ClaimStore {
+
+    private class Entry(val content: ByteArray, val generation: Long)
+
+    private val entries = HashMap<String, Entry>()
+    private var generationSequence = 0L
+
+    @Synchronized
+    override fun createIfAbsent(name: String, content: ByteArray): Boolean {
+        if (entries.containsKey(name)) return false
+        entries[name] = Entry(content.copyOf(), ++generationSequence)
+        return true
+    }
+
+    @Synchronized
+    override fun read(name: String): VersionedClaim? {
+        val entry = entries[name] ?: return null
+        return VersionedClaim(entry.content.copyOf(), entry.generation)
+    }
+
+    @Synchronized
+    override fun overwriteIfGeneration(name: String, content: ByteArray, expectedGeneration: Long): Boolean {
+        val entry = entries[name] ?: return false
+        if (entry.generation != expectedGeneration) return false
+        entries[name] = Entry(content.copyOf(), ++generationSequence)
+        return true
+    }
+
+    /** Test seam: seed a claim directly (used by the route integration test to force a bounce). */
+    @Synchronized
+    fun put(name: String, content: ByteArray) {
+        entries[name] = Entry(content.copyOf(), ++generationSequence)
+    }
+}

--- a/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/filter/FilterService.kt
@@ -4,6 +4,7 @@ import org.entur.netex.tools.lib.app.FilterNetexApp
 import org.entur.netex.tools.lib.config.FilterConfig
 import org.entur.netex.tools.lib.report.FilterReport
 import org.entur.ror.ashur.config.AppConfig
+import org.entur.ror.ashur.filteredOutputObjectPath
 import org.entur.ror.ashur.exceptions.InvalidZipFileException
 import org.entur.ror.ashur.exceptions.NoJourneysInNetexFileException
 import org.entur.ror.ashur.file.AshurBucketService
@@ -259,8 +260,7 @@ class FilterService(
         )
         logger.info("Filtering process for file ${netexInputFile.name} was successful")
 
-        val uploadPath = "${codespace}/${correlationId}"
-        val filteredZipFileName = "${uploadPath}/filtered_${netexInputFile.name}"
+        val filteredZipFileName = filteredOutputObjectPath(codespace, correlationId, netexInputFile.name)
         logger.info("Uploading filtered Netex zip file to Ashur bucket")
         filteredNetexZipFile.inputStream().use { inputStream ->
             ashurBucketService.uploadBlob(

--- a/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/metrics/FilterMetrics.kt
@@ -88,6 +88,19 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
             }
         }
 
+    /**
+     * Records the outcome of the redelivery guard for a delivery, tagged by [outcome] and [codespace].
+     * In Prometheus this surfaces as `ashur_filter_guard_total{outcome,codespace}` — the signal for
+     * whether the concurrent/crash redelivery cases actually occur in production.
+     */
+    fun recordGuardOutcome(outcome: String, codespace: String?) {
+        Counter.builder(GUARD_METRIC_NAME)
+            .tag("outcome", outcome)
+            .tag("codespace", codespace.orUnknown())
+            .register(meterRegistry)
+            .increment()
+    }
+
     private fun increment(status: String, codespace: String?) {
         Counter.builder(RUNS_METRIC_NAME)
             .tag("status", status)
@@ -107,5 +120,11 @@ class FilterMetrics(private val meterRegistry: MeterRegistry) {
         const val STATUS_SUCCESS = "success"
         const val STATUS_FAILED = "failed"
         const val UNKNOWN_CODESPACE = "unknown"
+        const val GUARD_METRIC_NAME = "ashur.filter.guard"
+        const val GUARD_OUTCOME_CLAIMED = "claimed"
+        const val GUARD_OUTCOME_SKIPPED_DONE = "skipped_already_done"
+        const val GUARD_OUTCOME_BOUNCED_FRESH = "bounced_claim_fresh"
+        const val GUARD_OUTCOME_TOOK_OVER_STALE = "took_over_stale"
+        const val GUARD_OUTCOME_FAIL_OPEN = "fail_open"
     }
 }

--- a/src/main/kotlin/org/entur/ror/ashur/pubsub/Claim.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/pubsub/Claim.kt
@@ -1,0 +1,13 @@
+package org.entur.ror.ashur.pubsub
+
+/**
+ * The ephemeral lease serialized into `claims/{codespace}/{correlationId}`. It exists only to
+ * serialize the in-flight window; it has no state machine and is never deleted by the app (a GCS
+ * lifecycle rule GCs it). [startedAtEpochMs] drives the staleness/TTL check; [owner] and [attempt]
+ * are for debugging/observability only.
+ */
+data class Claim(
+    val owner: String,
+    val startedAtEpochMs: Long,
+    val attempt: Int,
+)

--- a/src/main/kotlin/org/entur/ror/ashur/pubsub/RedeliveryGuard.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/pubsub/RedeliveryGuard.kt
@@ -1,0 +1,165 @@
+package org.entur.ror.ashur.pubsub
+
+import org.entur.ror.ashur.config.AppConfig
+import org.entur.ror.ashur.file.AshurBucketService
+import org.entur.ror.ashur.file.ClaimStore
+import org.entur.ror.ashur.metrics.FilterMetrics
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+/** What the caller should do with this delivery. */
+enum class GuardDecision { SKIP, PROCESS, BOUNCE }
+
+/** The minimal, message-derived facts the guard needs. [outputExists] is checked via [outputPath]. */
+data class GuardRequest(val codespace: String, val correlationId: String, val outputPath: String)
+
+/**
+ * Claim-based guard against duplicate/redundant processing of the same filter request. Runs on every
+ * delivery, before any work. Pub/Sub is at-least-once, so the same request can be delivered more than
+ * once; without this guard each delivery re-ran the whole pipeline (wasted compute, a re-sent
+ * SUCCEEDED, double-counted metrics).
+ *
+ * The delivery situations it distinguishes:
+ * - **First delivery of a request** — no output, no claim: we claim it and process. The normal path.
+ * - **Redelivery after the request already finished** (sequential duplicate) — the output artifact
+ *   already exists: skip. Happens when the original run completed but its message was redelivered
+ *   anyway (e.g. it finished right around the ack deadline, or the pod crashed *after* uploading the
+ *   output but before the ack).
+ * - **Redelivery while the original is still in flight** (concurrent duplicate) — a *fresh* claim
+ *   exists: bounce and let it be redelivered later. Happens when a run outlives the 600 s ack
+ *   deadline, so Pub/Sub redelivers it onto the other pod while the first pod is still filtering.
+ * - **Redelivery after the holder died mid-run** (crash recovery) — a *stale* claim exists: take it
+ *   over and process. Happens when the pod holding the claim was killed (OOM, eviction, deploy
+ *   SIGKILL) before finishing, so it never wrote the output and never got to ack.
+ *
+ * Invariant: a delivery is turned into an ack only when the work is genuinely done or proven done
+ * (output exists / we own the claim). "Someone else is (or was recently) working on it" is a
+ * [GuardDecision.BOUNCE] (nack), never an ack — so a crashed holder never causes an ack, and
+ * redeliveries keep coming until the claim goes stale and a redelivery takes it over.
+ */
+@Component
+class RedeliveryGuard(
+    private val claimStore: ClaimStore,
+    private val ashurBucketService: AshurBucketService,
+    private val filterMetrics: FilterMetrics,
+    appConfig: AppConfig,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val mapper = jacksonObjectMapper()
+
+    private val enabled = appConfig.redeliveryGuard.enabled
+    private val ttlMs = appConfig.redeliveryGuard.ttlSeconds * 1000
+    private val owner: String = System.getenv("HOSTNAME") ?: "unknown"
+
+    fun evaluate(request: GuardRequest, nowEpochMs: Long = System.currentTimeMillis()): GuardDecision {
+        if (!enabled) return GuardDecision.PROCESS
+
+        val codespace = request.codespace
+        val correlationId = request.correlationId
+
+        // Done-signal: the request already succeeded on an earlier delivery and its output is on the
+        // bucket. This is the sequential-duplicate case — a redelivery that arrived after completion.
+        // Nothing left to do, so ack and skip (no re-run, no STARTED/SUCCEEDED, no metrics).
+        if (ashurBucketService.exists(request.outputPath)) {
+            logger.info(
+                "Redelivery guard: output already exists for codespace={} correlationId={} at {}; skipping (ack, no re-processing).",
+                codespace, correlationId, request.outputPath,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE, codespace)
+            return GuardDecision.SKIP
+        }
+
+        val claimPath = "claims/$codespace/$correlationId"
+        return try {
+            decideOnClaim(claimPath, codespace, correlationId, nowEpochMs)
+        } catch (e: Exception) {
+            // Fail-open: the guard is a safety-net, not a correctness gate. A claim I/O error must
+            // degrade to today's behavior (process, tolerate a possible duplicate), never block.
+            logger.warn(
+                "Redelivery guard: claim I/O failed for codespace={} correlationId={}; failing open and processing anyway.",
+                codespace, correlationId, e,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_FAIL_OPEN, codespace)
+            GuardDecision.PROCESS
+        }
+    }
+
+    private fun decideOnClaim(claimPath: String, codespace: String, correlationId: String, nowEpochMs: Long): GuardDecision {
+        // We atomically win the claim iff no one else holds one. This is the normal first-delivery
+        // case: no other pod is (or was) working on this request, so we own it and process.
+        val created = claimStore.createIfAbsent(claimPath, serialize(Claim(owner, nowEpochMs, attempt = 1)))
+        if (created) {
+            logger.info("Redelivery guard: claimed codespace={} correlationId={}; processing.", codespace, correlationId)
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_CLAIMED, codespace)
+            return GuardDecision.PROCESS
+        }
+
+        val existing = claimStore.read(claimPath)
+        if (existing == null) {
+            // Effectively impossible: nothing deletes claims in-app and the lifecycle rule only
+            // touches 7-day-old objects. Treat a vanished claim as a lost race and bounce; a clean
+            // redelivery will re-attempt the claim.
+            logger.warn(
+                "Redelivery guard: claim for codespace={} correlationId={} vanished after a create conflict; bouncing.",
+                codespace, correlationId,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, codespace)
+            return GuardDecision.BOUNCE
+        }
+
+        val claim = deserialize(existing.content)
+        val ageMs = nowEpochMs - claim.startedAtEpochMs
+        // A claim exists and is still young (< TTL). We deliberately do NOT take it over yet: the
+        // holder is presumed alive. This covers two situations, and bouncing is right for both:
+        //  - the other pod is genuinely still filtering (a run that outlived the 600 s ack deadline
+        //    got redelivered onto us) — let it finish;
+        //  - the holder crashed only moments ago, so its claim hasn't aged into "stale" yet — wait it
+        //    out rather than start a racing second run.
+        // Either way we bounce (nack) so Pub/Sub redelivers later: if the holder finishes, the next
+        // delivery hits the done-signal above and skips; if it really crashed, the claim eventually
+        // crosses the TTL and a later redelivery takes it over (see below). We never ack here.
+        if (ageMs < ttlMs) {
+            logger.info(
+                "Redelivery guard: fresh claim (age={}ms < ttl={}ms, owner={}) for codespace={} correlationId={}; bouncing (nack) for redelivery.",
+                ageMs, ttlMs, claim.owner, codespace, correlationId,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, codespace)
+            return GuardDecision.BOUNCE
+        }
+
+        // The claim is stale (age >= TTL) yet the output still doesn't exist. The previous holder is
+        // presumed dead: it claimed the request, then was killed mid-run (OOM, eviction, deploy
+        // SIGKILL) before writing the output — otherwise the done-signal above would have fired. We
+        // take over the abandoned work. The overwrite is conditional on the generation we read, so if
+        // two pods both spot the same stale claim only one wins the compare-and-swap.
+        // Caveat: a *genuinely* slow-but-alive run that exceeds the TTL is indistinguishable from a
+        // crash and gets taken over too — a bounded, safe duplicate (both write the same object;
+        // last-writer-wins). TTL must therefore exceed the worst-case legitimate run duration.
+        val tookOver = claimStore.overwriteIfGeneration(
+            claimPath,
+            serialize(Claim(owner, nowEpochMs, attempt = claim.attempt + 1)),
+            existing.generation,
+        )
+        return if (tookOver) {
+            logger.info(
+                "Redelivery guard: took over stale claim (age={}ms >= ttl={}ms, prevOwner={}) for codespace={} correlationId={}; processing.",
+                ageMs, ttlMs, claim.owner, codespace, correlationId,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_TOOK_OVER_STALE, codespace)
+            GuardDecision.PROCESS
+        } else {
+            // Both pods saw the same stale claim and raced to take it over; the compare-and-swap let
+            // the other pod win, so it is now processing. Bounce (nack) — the winner owns the work.
+            logger.info(
+                "Redelivery guard: lost the takeover race for codespace={} correlationId={}; bouncing (nack).",
+                codespace, correlationId,
+            )
+            filterMetrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, codespace)
+            GuardDecision.BOUNCE
+        }
+    }
+
+    private fun serialize(claim: Claim): ByteArray = mapper.writeValueAsBytes(claim)
+    private fun deserialize(bytes: ByteArray): Claim = mapper.readValue(bytes, Claim::class.java)
+}

--- a/src/test/kotlin/org/entur/ror/ashur/ExtensionsTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/ExtensionsTest.kt
@@ -150,6 +150,21 @@ class ExtensionsTest {
         assertEquals("value", attributes["key"])
     }
 
+    // filteredOutputObjectPath
+
+    @Test
+    fun `filteredOutputObjectPath builds codespace correlation filtered-name and strips leading dirs`() {
+        assertEquals(
+            "RUT/corr-1/filtered_rb_rut-aggregated-netex.zip",
+            filteredOutputObjectPath("RUT", "corr-1", "rb_rut-aggregated-netex.zip"),
+        )
+        // A file handle with directories collapses to its leaf, matching File(fileName).name.
+        assertEquals(
+            "RUT/corr-1/filtered_rb_rut-aggregated-netex.zip",
+            filteredOutputObjectPath("RUT", "corr-1", "inbound/received/rb_rut-aggregated-netex.zip"),
+        )
+    }
+
     // helpers
 
     private fun pubsubMessage(vararg attributes: Pair<String, String>): PubsubMessage =

--- a/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/camel/NetexFilterRouteBuilderIntegrationTest.kt
@@ -49,6 +49,12 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
     @Autowired
     lateinit var meterRegistry: MeterRegistry
 
+    @Autowired
+    lateinit var claimStore: org.entur.ror.ashur.file.InMemoryClaimStore
+
+    @Autowired
+    lateinit var ashurBucketService: org.entur.ror.ashur.file.AshurBucketService
+
     private val testCodespace = "test-codespace"
     private val testSource = "test-source"
     private val testFilteringProfile = "AsIsImportFilter"
@@ -96,6 +102,22 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
             "no status message on ${Constants.FILTER_NETEX_FILE_STATUS_TOPIC} within ${timeoutMillis}ms",
         )
     }
+
+    private fun tryReceiveStatusMessage(timeoutMillis: Long): Exchange? {
+        val uri = "google-pubsub:${appConfig.gcp.mardukProjectId}:${Constants.FILTER_NETEX_FILE_STATUS_TOPIC}?synchronousPull=true"
+        return consumerTemplate.receive(uri, timeoutMillis)
+    }
+
+    /** Drain any status messages left over from earlier tests so an assertion window starts clean. */
+    private fun drainStatusMessages() {
+        while (tryReceiveStatusMessage(500) != null) { /* discard */ }
+    }
+
+    private fun guardCount(outcome: String): Double =
+        meterRegistry.find(FilterMetrics.GUARD_METRIC_NAME)
+            .tags("outcome", outcome, "codespace", testCodespace)
+            .counter()
+            ?.count() ?: 0.0
 
     fun fileExistsInAshurInternalBucket(filePath: String): Boolean {
         val target = File("${appConfig.local.blobstorePath}/${appConfig.gcp.ashurBucketName}/$filePath")
@@ -205,5 +227,49 @@ class NetexFilterRouteBuilderIntegrationTest: PubSubEmulatorTestBase() {
         assertEquals(durationRunsBefore, durationRunCount())
 
         cleanupTestZipFiles()
+    }
+
+    @Test
+    fun `guard skips redelivery when filtered output already exists`() {
+        drainStatusMessages()
+        val correlationId = "already-done-correlation-id"
+        // Pre-seed the done-signal: the filtered output already exists in the internal bucket.
+        val outputPath = pathOfFilteredFile("testfile.zip", correlationId)
+        ashurBucketService.uploadBlob(outputPath, "already-filtered".byteInputStream())
+        val skippedBefore = guardCount(FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE)
+        val successRunsBefore = runCount(FilterMetrics.STATUS_SUCCESS)
+
+        sendFilterMessageToPubsub(netexFilePath = "testfile.zip", correlationId = correlationId)
+
+        // No STARTED / SUCCEEDED / FAILED status is published — the route acks and stops.
+        val status = tryReceiveStatusMessage(4000)
+        assertEquals(null, status, "expected no status message on a skipped redelivery, got ${status?.toPubsubMessage()?.getStatus()}")
+        assertEquals(skippedBefore + 1.0, guardCount(FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE))
+        assertEquals(successRunsBefore, runCount(FilterMetrics.STATUS_SUCCESS))
+    }
+
+    @Test
+    fun `guard bounces (no FAILED, no SUCCEEDED) when a fresh claim is held by another pod`() {
+        drainStatusMessages()
+        val correlationId = "fresh-claim-correlation-id"
+        // Simulate the other pod holding a fresh claim.
+        claimStore.put(
+            "claims/$testCodespace/$correlationId",
+            mapper.writeValueAsBytes(
+                org.entur.ror.ashur.pubsub.Claim(owner = "other-pod", startedAtEpochMs = System.currentTimeMillis(), attempt = 1),
+            ),
+        )
+        val bouncedBefore = guardCount(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH)
+
+        sendFilterMessageToPubsub(netexFilePath = "testfile.zip", correlationId = correlationId)
+
+        // The bounce is nacked, not turned into a FAILED status.
+        val status = tryReceiveStatusMessage(4000)
+        assertEquals(null, status, "expected no status message on a bounce, got ${status?.toPubsubMessage()?.getStatus()}")
+        assertTrue(guardCount(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH) > bouncedBefore)
+
+        // Drain the bounced message cleanly: seed its output so the next redelivery skips+acks rather
+        // than perpetually re-bouncing, which would otherwise starve sibling tests' single consumer.
+        ashurBucketService.uploadBlob(pathOfFilteredFile("testfile.zip", correlationId), "done".byteInputStream())
     }
 }

--- a/src/test/kotlin/org/entur/ror/ashur/camel/RedeliveryGuardProcessorTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/camel/RedeliveryGuardProcessorTest.kt
@@ -1,0 +1,95 @@
+package org.entur.ror.ashur.camel
+
+import org.apache.camel.impl.DefaultCamelContext
+import org.apache.camel.support.DefaultExchange
+import org.entur.ror.ashur.Constants
+import org.entur.ror.ashur.exceptions.ClaimHeldException
+import org.entur.ror.ashur.pubsub.GuardDecision
+import org.entur.ror.ashur.pubsub.GuardRequest
+import org.entur.ror.ashur.pubsub.RedeliveryGuard
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RedeliveryGuardProcessorTest {
+
+    private val camelContext = DefaultCamelContext()
+
+    private fun exchangeFor(fileName: String, codespace: String, correlationId: String): DefaultExchange {
+        val exchange = DefaultExchange(camelContext)
+        exchange.getIn().body = ""
+        exchange.getIn().setHeader(
+            "CamelGooglePubsubAttributes",
+            mapOf(
+                Constants.CODESPACE_HEADER to codespace,
+                Constants.CORRELATION_ID_HEADER to correlationId,
+                Constants.NETEX_FILE_NAME_HEADER to fileName,
+            ),
+        )
+        return exchange
+    }
+
+    @Test
+    fun `PROCESS leaves the exchange untouched`() {
+        val guard = mock<RedeliveryGuard> { on { evaluate(any(), any()) } doReturn GuardDecision.PROCESS }
+        val exchange = exchangeFor("data.zip", "RUT", "corr-1")
+
+        RedeliveryGuardProcessor(guard).process(exchange)
+
+        assertNull(exchange.getIn().getHeader(Constants.GUARD_DECISION_HEADER))
+    }
+
+    @Test
+    fun `SKIP sets the skip decision header`() {
+        val guard = mock<RedeliveryGuard> { on { evaluate(any(), any()) } doReturn GuardDecision.SKIP }
+        val exchange = exchangeFor("data.zip", "RUT", "corr-1")
+
+        RedeliveryGuardProcessor(guard).process(exchange)
+
+        assertEquals(Constants.GUARD_DECISION_SKIP, exchange.getIn().getHeader(Constants.GUARD_DECISION_HEADER))
+    }
+
+    @Test
+    fun `BOUNCE throws ClaimHeldException`() {
+        val guard = mock<RedeliveryGuard> { on { evaluate(any(), any()) } doReturn GuardDecision.BOUNCE }
+        val exchange = exchangeFor("data.zip", "RUT", "corr-1")
+
+        assertThrows<ClaimHeldException> { RedeliveryGuardProcessor(guard).process(exchange) }
+    }
+
+    @Test
+    fun `derives the guard request output path from message attributes`() {
+        val guard = mock<RedeliveryGuard> { on { evaluate(any(), any()) } doReturn GuardDecision.PROCESS }
+        val exchange = exchangeFor("inbound/data.zip", "RUT", "corr-1")
+
+        RedeliveryGuardProcessor(guard).process(exchange)
+
+        val captor = argumentCaptor<GuardRequest>()
+        org.mockito.kotlin.verify(guard).evaluate(captor.capture(), any())
+        assertEquals("RUT", captor.firstValue.codespace)
+        assertEquals("corr-1", captor.firstValue.correlationId)
+        assertEquals("RUT/corr-1/filtered_data.zip", captor.firstValue.outputPath)
+    }
+
+    @Test
+    fun `skips guarding and processes when a required attribute is missing`() {
+        val guard = mock<RedeliveryGuard>()
+        val exchange = DefaultExchange(camelContext)
+        exchange.getIn().body = ""
+        // No file handle attribute -> cannot derive the output path.
+        exchange.getIn().setHeader(
+            "CamelGooglePubsubAttributes",
+            mapOf(Constants.CODESPACE_HEADER to "RUT", Constants.CORRELATION_ID_HEADER to "corr-1"),
+        )
+
+        RedeliveryGuardProcessor(guard).process(exchange)
+
+        org.mockito.kotlin.verifyNoInteractions(guard)
+        assertNull(exchange.getIn().getHeader(Constants.GUARD_DECISION_HEADER))
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/file/GcsClaimStoreTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/file/GcsClaimStoreTest.kt
@@ -1,0 +1,88 @@
+package org.entur.ror.ashur.file
+
+import com.google.cloud.storage.Blob
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageException
+import org.entur.ror.ashur.config.AppConfig
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GcsClaimStoreTest {
+
+    private val bucket = "ror-ashur-internal-gcp-test"
+    private val appConfig = AppConfig(
+        gcp = AppConfig.GcpConfig().also { it.ashurBucketName = bucket }
+    )
+
+    private fun storeWith(storage: Storage) = GcsClaimStore(storage, appConfig)
+
+    @Test
+    fun `createIfAbsent returns true when the create succeeds`() {
+        val storage = mock<Storage> {
+            on { create(any<BlobInfo>(), any<ByteArray>(), any<Storage.BlobTargetOption>()) } doReturn mock<Blob>()
+        }
+        assertTrue(storeWith(storage).createIfAbsent("claims/RUT/c1", "x".toByteArray()))
+    }
+
+    @Test
+    fun `createIfAbsent returns false on a 412 precondition failure`() {
+        val storage = mock<Storage> {
+            on { create(any<BlobInfo>(), any<ByteArray>(), any<Storage.BlobTargetOption>()) } doThrow StorageException(412, "precondition")
+        }
+        assertFalse(storeWith(storage).createIfAbsent("claims/RUT/c1", "x".toByteArray()))
+    }
+
+    @Test
+    fun `createIfAbsent rethrows non-412 storage errors so the guard can fail open`() {
+        val storage = mock<Storage> {
+            on { create(any<BlobInfo>(), any<ByteArray>(), any<Storage.BlobTargetOption>()) } doThrow StorageException(503, "unavailable")
+        }
+        assertThrows<StorageException> { storeWith(storage).createIfAbsent("claims/RUT/c1", "x".toByteArray()) }
+    }
+
+    @Test
+    fun `read returns null when the blob is absent`() {
+        val storage = mock<Storage> {
+            on { get(any<BlobId>()) } doReturn null
+        }
+        assertNull(storeWith(storage).read("claims/RUT/c1"))
+    }
+
+    @Test
+    fun `read returns content and generation when present`() {
+        val blob = mock<Blob> {
+            on { getContent() } doReturn "payload".toByteArray()
+            on { getGeneration() } doReturn 42L
+        }
+        val storage = mock<Storage> {
+            on { get(eq(BlobId.of(bucket, "claims/RUT/c1"))) } doReturn blob
+        }
+        val versioned = storeWith(storage).read("claims/RUT/c1")!!
+        assertEquals("payload", String(versioned.content))
+        assertEquals(42L, versioned.generation)
+    }
+
+    @Test
+    fun `overwriteIfGeneration returns true on success and false on 412`() {
+        val ok = mock<Storage> {
+            on { create(any<BlobInfo>(), any<ByteArray>(), any<Storage.BlobTargetOption>()) } doReturn mock<Blob>()
+        }
+        assertTrue(storeWith(ok).overwriteIfGeneration("claims/RUT/c1", "x".toByteArray(), 7L))
+
+        val conflict = mock<Storage> {
+            on { create(any<BlobInfo>(), any<ByteArray>(), any<Storage.BlobTargetOption>()) } doThrow StorageException(412, "precondition")
+        }
+        assertFalse(storeWith(conflict).overwriteIfGeneration("claims/RUT/c1", "x".toByteArray(), 7L))
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/file/InMemoryClaimStoreTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/file/InMemoryClaimStoreTest.kt
@@ -1,0 +1,50 @@
+package org.entur.ror.ashur.file
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InMemoryClaimStoreTest {
+
+    @Test
+    fun `createIfAbsent returns true the first time and false when it already exists`() {
+        val store = InMemoryClaimStore()
+        assertTrue(store.createIfAbsent("claims/RUT/c1", "first".toByteArray()))
+        assertFalse(store.createIfAbsent("claims/RUT/c1", "second".toByteArray()))
+    }
+
+    @Test
+    fun `read returns null when absent and content plus generation when present`() {
+        val store = InMemoryClaimStore()
+        assertNull(store.read("claims/RUT/c1"))
+
+        store.createIfAbsent("claims/RUT/c1", "payload".toByteArray())
+        val versioned = store.read("claims/RUT/c1")!!
+
+        assertEquals("payload", String(versioned.content))
+        assertTrue(versioned.generation > 0)
+    }
+
+    @Test
+    fun `overwriteIfGeneration succeeds only when the expected generation matches`() {
+        val store = InMemoryClaimStore()
+        store.createIfAbsent("claims/RUT/c1", "v1".toByteArray())
+        val gen = store.read("claims/RUT/c1")!!.generation
+
+        assertFalse(store.overwriteIfGeneration("claims/RUT/c1", "stale".toByteArray(), gen + 999))
+        assertEquals("v1", String(store.read("claims/RUT/c1")!!.content))
+
+        assertTrue(store.overwriteIfGeneration("claims/RUT/c1", "v2".toByteArray(), gen))
+        val after = store.read("claims/RUT/c1")!!
+        assertEquals("v2", String(after.content))
+        assertTrue(after.generation != gen)
+    }
+
+    @Test
+    fun `overwriteIfGeneration returns false when the object does not exist`() {
+        val store = InMemoryClaimStore()
+        assertFalse(store.overwriteIfGeneration("claims/RUT/missing", "x".toByteArray(), 1L))
+    }
+}

--- a/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/metrics/FilterMetricsTest.kt
@@ -236,4 +236,37 @@ class FilterMetricsTest {
 
         assertEquals(10.0, serviceJourneysOriginal(registry, "unknown"))
     }
+
+    private fun guardCount(
+        registry: SimpleMeterRegistry,
+        outcome: String,
+        codespace: String,
+    ): Double =
+        registry.find(FilterMetrics.GUARD_METRIC_NAME)
+            .tags("outcome", outcome, "codespace", codespace)
+            .counter()
+            ?.count() ?: 0.0
+
+    @Test
+    fun `recordGuardOutcome counts per outcome and codespace`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, "RUT")
+        metrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, "RUT")
+        metrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE, "RUT")
+
+        assertEquals(2.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH, "RUT"))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE, "RUT"))
+    }
+
+    @Test
+    fun `recordGuardOutcome records null codespace as unknown`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = FilterMetrics(registry)
+
+        metrics.recordGuardOutcome(FilterMetrics.GUARD_OUTCOME_FAIL_OPEN, null)
+
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_FAIL_OPEN, "unknown"))
+    }
 }

--- a/src/test/kotlin/org/entur/ror/ashur/pubsub/RedeliveryGuardTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/pubsub/RedeliveryGuardTest.kt
@@ -1,0 +1,116 @@
+package org.entur.ror.ashur.pubsub
+
+import com.google.cloud.storage.StorageException
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.entur.ror.ashur.config.AppConfig
+import org.entur.ror.ashur.file.AshurBucketService
+import org.entur.ror.ashur.file.ClaimStore
+import org.entur.ror.ashur.file.InMemoryClaimStore
+import org.entur.ror.ashur.metrics.FilterMetrics
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RedeliveryGuardTest {
+
+    private val ttlSeconds = 1200L
+    private val ttlMs = ttlSeconds * 1000
+    private val outputPath = "RUT/corr-1/filtered_data.zip"
+    private val claimPath = "claims/RUT/corr-1"
+    private val request = GuardRequest(codespace = "RUT", correlationId = "corr-1", outputPath = outputPath)
+    private val mapper = jacksonObjectMapper()
+
+    private fun appConfig(enabled: Boolean = true) = AppConfig(
+        redeliveryGuard = AppConfig.RedeliveryGuardConfig().also {
+            it.enabled = enabled
+            it.ttlSeconds = ttlSeconds
+        }
+    )
+
+    private fun guard(
+        claimStore: ClaimStore,
+        outputExists: Boolean,
+        enabled: Boolean = true,
+    ): Pair<RedeliveryGuard, SimpleMeterRegistry> {
+        val registry = SimpleMeterRegistry()
+        val bucket = mock<AshurBucketService> { on { exists(outputPath) } doReturn outputExists }
+        val guard = RedeliveryGuard(claimStore, bucket, FilterMetrics(registry), appConfig(enabled))
+        return guard to registry
+    }
+
+    private fun guardCount(registry: SimpleMeterRegistry, outcome: String) =
+        registry.find(FilterMetrics.GUARD_METRIC_NAME).tags("outcome", outcome, "codespace", "RUT")
+            .counter()?.count() ?: 0.0
+
+    @Test
+    fun `skips when the output already exists`() {
+        val store = InMemoryClaimStore()
+        val (guard, registry) = guard(store, outputExists = true)
+
+        assertEquals(GuardDecision.SKIP, guard.evaluate(request, nowEpochMs = 1_000))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE))
+    }
+
+    @Test
+    fun `claims and processes when no output and no existing claim`() {
+        val store = InMemoryClaimStore()
+        val (guard, registry) = guard(store, outputExists = false)
+
+        assertEquals(GuardDecision.PROCESS, guard.evaluate(request, nowEpochMs = 1_000))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_CLAIMED))
+    }
+
+    @Test
+    fun `bounces when a fresh claim already exists`() {
+        val store = InMemoryClaimStore()
+        store.put(claimPath, mapper.writeValueAsBytes(Claim(owner = "pod-a", startedAtEpochMs = 1_000, attempt = 1)))
+        val (guard, registry) = guard(store, outputExists = false)
+
+        // now is only 10s after the claim started; well under the 1200s TTL.
+        assertEquals(GuardDecision.BOUNCE, guard.evaluate(request, nowEpochMs = 11_000))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_BOUNCED_FRESH))
+    }
+
+    @Test
+    fun `takes over and processes when the existing claim is stale`() {
+        val store = InMemoryClaimStore()
+        store.put(claimPath, mapper.writeValueAsBytes(Claim(owner = "pod-a", startedAtEpochMs = 1_000, attempt = 1)))
+        val (guard, registry) = guard(store, outputExists = false)
+
+        val now = 1_000 + ttlMs + 1 // just past the TTL
+        assertEquals(GuardDecision.PROCESS, guard.evaluate(request, nowEpochMs = now))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_TOOK_OVER_STALE))
+
+        // the claim was overwritten with a bumped attempt and refreshed start time
+        val rewritten = mapper.readValue(store.read(claimPath)!!.content, Claim::class.java)
+        assertEquals(2, rewritten.attempt)
+        assertEquals(now, rewritten.startedAtEpochMs)
+    }
+
+    @Test
+    fun `no-op processes when the guard is disabled and does not skip on existing output`() {
+        val store = InMemoryClaimStore()
+        // outputExists=true would normally SKIP; disabled must still PROCESS.
+        val (guard, registry) = guard(store, outputExists = true, enabled = false)
+
+        assertEquals(GuardDecision.PROCESS, guard.evaluate(request, nowEpochMs = 1_000))
+        assertEquals(0.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_SKIPPED_DONE))
+    }
+
+    @Test
+    fun `fails open and processes when the claim store throws`() {
+        val registry = SimpleMeterRegistry()
+        val bucket = mock<AshurBucketService> { on { exists(outputPath) } doReturn false }
+        val throwingStore = mock<ClaimStore> {
+            on { createIfAbsent(any(), any()) } doThrow StorageException(503, "unavailable")
+        }
+        val guard = RedeliveryGuard(throwingStore, bucket, FilterMetrics(registry), appConfig())
+
+        assertEquals(GuardDecision.PROCESS, guard.evaluate(request, nowEpochMs = 1_000))
+        assertEquals(1.0, guardCount(registry, FilterMetrics.GUARD_OUTCOME_FAIL_OPEN))
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,6 +10,9 @@ ashur.gcp.marduk-bucket-name=test
 
 ashur.local.blobstorePath=target/blobstore
 
+ashur.redelivery-guard.enabled=true
+ashur.redelivery-guard.ttl-seconds=1200
+
 camel.component.google-pubsub.endpoint=localhost:8085
 camel.component.google-pubsub.authenticate=false
 camel.component.google-pubsub.projectId=test

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -23,6 +23,20 @@ resource "google_storage_bucket" "storage_bucket" {
       type = "Delete"
     }
   }
+  # Redelivery-guard claim leases (claims/{codespace}/{correlationId}) are never deleted by the app;
+  # they only have to outlive the 7-day Pub/Sub message retention. Delete them at 8 days (a day of
+  # margin) so they don't linger the full retention period. The blanket rule above already GCs them
+  # eventually, so this is a faster-cleanup optimisation, not a correctness requirement.
+  lifecycle_rule {
+    condition {
+      age            = 8
+      matches_prefix = ["claims/"]
+      with_state     = "ANY"
+    }
+    action {
+      type = "Delete"
+    }
+  }
 }
 
 resource "google_storage_bucket" "exchange_bucket" {


### PR DESCRIPTION
Pub/Sub delivers at-least-once, so a redelivery of the same filter request re-ran the whole download→filter→upload pipeline. The end result is unchanged — the stored output converges (same object path, deterministic filter, last-writer-wins) and Marduk is idempotent on a repeated SUCCEEDED for the same correlationId — but each redelivery wasted compute, re-sent SUCCEEDED, and double-counted metrics.

A guard now runs before STARTED on every delivery:
- skip (ack) if the filtered output already exists;
- otherwise atomically claim claims/{codespace}/{correlationId} in the internal bucket via a GCS generation precondition — the winner processes, a loser bounces (nack) on a fresh claim or takes over a stale one (age ≥ TTL);
- fail-open on claim I/O errors (degrade to today's behaviour).