### PR TITLE
Adds PrivateCode fallback for line file names

### DIFF
--- a/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilder.kt
@@ -32,6 +32,8 @@ class FileNameBuilder {
         return this
     }
 
+    fun firstCode(): String = sanitize(linePrivateCode.ifEmpty { linePublicCode })
+
     private fun sanitize(fileNameString: String): String {
         val transliterated = buildString(fileNameString.length) {
             for (ch in fileNameString) {
@@ -45,7 +47,7 @@ class FileNameBuilder {
     }
 
     fun build(): String {
-        return "${codespace.uppercase()}_${codespace.uppercase()}-${lineType}-${linePrivateCode}_${linePublicCode}_${lineName}.xml"
+        return "${codespace.uppercase()}_${codespace.uppercase()}-${lineType}-${firstCode()}_${linePublicCode}_${lineName}.xml"
     }
 
     companion object {

--- a/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilderTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilderTest.kt
@@ -63,6 +63,27 @@ class FileNameBuilderTest {
     }
 
     @Test
+    fun testBuildWithEmptyPrivateCode() {
+        val codespace = "TestCodespace"
+        val lineType = "TestLineType"
+        val lineName = "TestLineName"
+        val publicCode = "TestPublicCode"
+        val privateCode = ""
+
+        val expectedFileName = "TESTCODESPACE_TESTCODESPACE-TestLineType-TestPublicCode_TestPublicCode_TestLineName.xml"
+
+        val fileName = fileNameBuilder
+            .withCodespace(codespace)
+            .withLineType(lineType)
+            .withLineName(lineName)
+            .withLinePublicCode(publicCode)
+            .withLinePrivateCode(privateCode)
+            .build()
+
+        assertEquals(expectedFileName, fileName)
+    }
+
+    @Test
     fun sanitizesNordicAndUmlautDiacritics() {
         val fileName = fileNameBuilder
             .withCodespace("TST")


### PR DESCRIPTION
Not all datasets have a PrivateCode element on Line entities. This commit ensures that if it is missing, we use the PublicCode as a fallback in this position of the line file name, rather than empty string