### PR TITLE
Stop logging redelivery-guard bounces as delivery failures

### DIFF
--- a/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/camel/BaseRouteBuilder.kt
@@ -34,8 +34,17 @@ open class BaseRouteBuilder(
 
         // A bounce is NOT a failure: do not publish FAILED, and handled(false) lets the exception
         // propagate so the Pub/Sub consumer nacks the message and the server redelivers it later.
+        //
+        // Without the log* suppressions below, every bounce also went through the default error
+        // handler's "Failed delivery ... Exhausted after delivery attempt: 1" at ERROR, with a stack
+        // trace. A run whose duration exceeds the ack deadline bounces repeatedly, so a perfectly
+        // healthy run produced a burst of ERROR entries. These are scoped to ClaimHeldException, so
+        // genuine failures still log in full.
         onException(ClaimHeldException::class.java)
             .handled(false)
+            .logExhausted(false)
+            .logStackTrace(false)
+            .logExhaustedMessageHistory(false)
             .log(
                 LoggingLevel.INFO,
                 "Redelivery guard bounced message from Pub/Sub topic $filterSubscription (nack for redelivery): \${exception.message}",


### PR DESCRIPTION
A bounce is normal control flow — another pod holds the claim, so the message is nacked and comes back later. It still went through Camel's default error handler, which logged `Failed delivery ... Exhausted after delivery attempt: 1` at ERROR with a stack trace on every bounce.

Since a bounce repeats until the holder finishes, a healthy run produced a burst of ERRORs: 121 of them in one integration-test run. The filtering-failures alert keys on the FAILED status message rather than severity, so this was misleading logs, not false alarms.

`logExhausted`/`logStackTrace`/`logExhaustedMessageHistory` are scoped to `ClaimHeldException`, so genuine failures still log in full. One WARNING per bounce remains — it comes from the Pub/Sub consumer's own `ExceptionHandler`, which is per-endpoint rather than per-exception-type.

Verified on the bounce integration test: ERROR `Failed delivery` went 121 → 0. Full suite green at 300 tests.