### PR TITLE
LineId fallback on line file names

### DIFF
--- a/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilder.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilder.kt
@@ -2,10 +2,16 @@ package org.entur.ror.ashur.sax.plugins.filenames
 
 class FileNameBuilder {
     var codespace: String = ""
+    var lineId: String = ""
     var lineType: String = ""
     var lineName: String = ""
     var linePublicCode: String = ""
     var linePrivateCode: String = ""
+
+    fun withLineId(id: String): FileNameBuilder {
+        this.lineId = sanitize(id)
+        return this
+    }
 
     fun withCodespace(codespace: String): FileNameBuilder {
         this.codespace = sanitize(codespace)
@@ -23,7 +29,8 @@ class FileNameBuilder {
     }
 
     fun withLinePublicCode(linePublicCode: String): FileNameBuilder {
-        this.linePublicCode = sanitize(linePublicCode)
+        // Trimmed so that a whitespace-only PublicCode counts as absent in build()
+        this.linePublicCode = sanitize(linePublicCode, trimWhitespace = true)
         return this
     }
 
@@ -34,9 +41,10 @@ class FileNameBuilder {
 
     fun firstCode(): String = sanitize(linePrivateCode.ifEmpty { linePublicCode })
 
-    private fun sanitize(fileNameString: String): String {
-        val transliterated = buildString(fileNameString.length) {
-            for (ch in fileNameString) {
+    private fun sanitize(fileNameString: String, trimWhitespace: Boolean = false): String {
+        val input = if (trimWhitespace) fileNameString.trim() else fileNameString
+        val transliterated = buildString(input.length) {
+            for (ch in input) {
                 val mapped = TRANSLITERATION[ch]
                 if (mapped != null) append(mapped) else append(ch)
             }
@@ -47,6 +55,9 @@ class FileNameBuilder {
     }
 
     fun build(): String {
+        if (linePublicCode.isEmpty()) {
+            return "${codespace.uppercase()}_${lineId}_${lineName}.xml"
+        }
         return "${codespace.uppercase()}_${codespace.uppercase()}-${lineType}-${firstCode()}_${linePublicCode}_${lineName}.xml"
     }
 

--- a/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePlugin.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePlugin.kt
@@ -20,6 +20,7 @@ class FileNamePlugin(
         }
         if (elementName == "FlexibleLine" || elementName == "Line") {
             context.lineType = elementName
+            attributes?.getValue("id")?.let { context.lineId = it }
         }
     }
 
@@ -47,6 +48,7 @@ class FileNamePlugin(
         }
 
         val newFileName = FileNameBuilder()
+            .withLineId(context.lineId)
             .withLineName(context.lineName.toString())
             .withLinePublicCode(context.linePublicCode.toString())
             .withLinePrivateCode(context.linePrivateCode.toString())

--- a/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePluginContext.kt
+++ b/src/main/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePluginContext.kt
@@ -1,12 +1,14 @@
 package org.entur.ror.ashur.sax.plugins.filenames
 
 class FileNamePluginContext{
+    var lineId: String = ""
     var lineType: String = ""
     var lineName: StringBuilder = StringBuilder()
     var linePublicCode: StringBuilder = StringBuilder()
     var linePrivateCode: StringBuilder = StringBuilder()
 
     fun reset() {
+        lineId = ""
         lineType = ""
         lineName.clear()
         linePublicCode.clear()

--- a/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilderTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNameBuilderTest.kt
@@ -28,6 +28,13 @@ class FileNameBuilderTest {
     }
 
     @Test
+    fun withLineId() {
+        val lineId = "TestLineId"
+        fileNameBuilder.withLineId(lineId)
+        assertEquals(lineId, fileNameBuilder.lineId)
+    }
+
+    @Test
     fun withLinePublicCode() {
         val publicCode = "TestPublicCode"
         fileNameBuilder.withLinePublicCode(publicCode)
@@ -57,6 +64,25 @@ class FileNameBuilderTest {
             .withLineName(lineName)
             .withLinePublicCode(publicCode)
             .withLinePrivateCode(privateCode)
+            .build()
+
+        assertEquals(expectedFileName, fileName)
+    }
+
+    @Test
+    fun testBuildWithEmptyPublicCode() {
+        val codespace = "TestCodespace"
+        val lineType = "TestLineType"
+        val lineName = "TestLineName"
+        val lineId = "AVI:Line:WF_ALF-VDS"
+
+        val expectedFileName = "TESTCODESPACE_AVI-Line-WF_ALF-VDS_TestLineName.xml"
+
+        val fileName = fileNameBuilder
+            .withCodespace(codespace)
+            .withLineType(lineType)
+            .withLineName(lineName)
+            .withLineId(lineId)
             .build()
 
         assertEquals(expectedFileName, fileName)
@@ -159,6 +185,90 @@ class FileNameBuilderTest {
 
         assertEquals(
             "TST_TST-Line-X_1_Linjetest.xml",
+            fileName,
+        )
+    }
+
+    @Test
+    fun whitespaceOnlyPublicCodeCountsAsAbsentAndFallsBackToLineId() {
+        val fileName = fileNameBuilder
+            .withCodespace("TST")
+            .withLineType("Line")
+            .withLineName("TestLineName")
+            .withLinePublicCode("   ")
+            .withLineId("AVI:Line:WF")
+            .build()
+
+        assertEquals(
+            "TST_AVI-Line-WF_TestLineName.xml",
+            fileName,
+        )
+    }
+
+    @Test
+    fun trimsSurroundingWhitespaceInPublicCode() {
+        val fileName = fileNameBuilder
+            .withCodespace("TST")
+            .withLineType("Line")
+            .withLineName("TestLineName")
+            .withLinePublicCode("\n  12\n  ")
+            .withLinePrivateCode("X")
+            .build()
+
+        assertEquals(
+            "TST_TST-Line-X_12_TestLineName.xml",
+            fileName,
+        )
+    }
+
+    @Test
+    fun trimsPublicCodeOnlyAndLeavesOtherFieldsUntouched() {
+        val fileName = fileNameBuilder
+            .withCodespace("TST")
+            .withLineType("Line")
+            .withLineName("  Bussen  ")
+            .withLinePublicCode("1")
+            .withLinePrivateCode("X")
+            .build()
+
+        assertEquals(
+            "TST_TST-Line-X_1_--Bussen--.xml",
+            fileName,
+        )
+    }
+
+    @Test
+    fun withLineIdSanitizesOnAssignment() {
+        fileNameBuilder.withLineId("AVI:Line:../x")
+        assertEquals("AVI-Line----x", fileNameBuilder.lineId)
+    }
+
+    @Test
+    fun sanitizesPathSeparatorsAndTraversalInLineId() {
+        val fileName = fileNameBuilder
+            .withCodespace("TST")
+            .withLineType("Line")
+            .withLineName("TestLineName")
+            .withLineId("AVI:Line:../../etc/tst x")
+            .build()
+
+        assertEquals(
+            "TST_AVI-Line-------etc-tst-x_TestLineName.xml",
+            fileName,
+        )
+    }
+
+    @Test
+    fun sanitizesNonAsciiInLineId() {
+        val fileName = fileNameBuilder
+            .withCodespace("TST")
+            .withLineType("Line")
+            .withLineName("TestLineName")
+            .withLineId("AVI:Line:Ålesund–α")
+            .build()
+
+        assertEquals(
+            "TST_AVI-Line-Alesund_TestLineName.xml",
             fileName,
         )
     }

--- a/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePluginTest.kt
+++ b/src/test/kotlin/org/entur/ror/ashur/sax/plugins/filenames/FileNamePluginTest.kt
@@ -40,11 +40,20 @@ class FileNamePluginTest {
     }
 
     @Test
+    fun testStartElementCapturesLineId() {
+        val lineAttrs = AttributesImpl()
+        lineAttrs.addAttribute("", "id", "id", "CDATA", "AVI:Line:WF_ALF-VDS")
+        fileNamePlugin.startElement("Line", lineAttrs, null)
+        assertEquals("AVI:Line:WF_ALF-VDS", context.lineId)
+    }
+
+    @Test
     fun testStartElementForNonLineElement() {
         val journeyAttrs = AttributesImpl()
         journeyAttrs.addAttribute("", "id", "id", "CDATA", "servicejourney1")
         fileNamePlugin.startElement("ServiceJourney", journeyAttrs, null)
         assertEquals( "", context.lineType)
+        assertEquals("", context.lineId)
     }
 
     @Test


### PR DESCRIPTION
Datasets that have no explicit PublicCode on Line have increased risk of producing duplicate file names. Actual overwriting of files does not happen due to the safeguard in Ashur that add increasing numbers to file names in these cases, so the real likely consequence of this should be purely cosmetic.

This commit addresses this cosmetic issue by adding an additional fallback mechanism to the naming of Line files. The fallback says that if no PublicCode is defined on a Line for a Line file, the Line.id is used for the first part of the Line file name instead of codespace + privatecode + publiccode.